### PR TITLE
Redesign: marketeer-feedback frontend updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,16 @@ function App() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false);
   const [scrolled, setScrolled] = React.useState(false);
   const { user, loading, signOut } = useAuth();
-  const { t } = useI18n();
+  const { t, currentLanguage } = useI18n();
   const navigate = useNavigate();
+  // "Start free" CTA label for the mobile menu only (desktop nav keeps
+  // navigation.getStarted). Inline map so we don't touch shared locale JSON.
+  const startFreeLabel = ({
+    nl: 'Start gratis',
+    en: 'Start free',
+    fr: 'Commencer gratuitement',
+    de: 'Kostenlos starten',
+  } as Record<string, string>)[currentLanguage] ?? 'Start free';
   const location = useLocation();
   const { navigateWithTransition } = usePageTransition();
 
@@ -273,9 +281,9 @@ function App() {
             <button
               onClick={() => setIsMobileMenuOpen(true)}
               aria-label="Open menu"
-              className="min-[868px]:hidden fixed top-3 right-4 z-[10000] p-2.5 bg-white/90 backdrop-blur-sm shadow-sm text-gray-700 hover:text-gray-900 hover:bg-white rounded-full transition-all duration-200"
+              className="min-[868px]:hidden fixed top-3 right-4 z-[10000] p-3 bg-navy hover:bg-navy-hover text-white shadow-[6px_8px_18px_rgba(0,0,0,0.30),2px_3px_6px_rgba(0,0,0,0.22)] rounded-full transition-all duration-200"
             >
-              <Menu className="w-6 h-6" />
+              <Menu className="w-7 h-7" />
             </button>
           )}
 
@@ -304,7 +312,7 @@ function App() {
                 {user ? (
                   <button
                     onClick={() => { setIsMobileMenuOpen(false); navigate(withUTM('/dashboard')); }}
-                    className="w-full bg-navy hover:bg-navy-hover text-white font-semibold py-4 rounded-full flex items-center justify-center gap-2 text-base transition-colors"
+                    className="w-full bg-navy hover:bg-navy-hover text-white font-semibold py-4 rounded-full flex items-center justify-center gap-2 text-lg transition-colors"
                   >
                     <span>{t('navigation.dashboard')}</span>
                     <ArrowRight className="w-5 h-5" />
@@ -312,9 +320,9 @@ function App() {
                 ) : (
                   <button
                     onClick={() => { setIsMobileMenuOpen(false); navigate(withUTM('/signup')); }}
-                    className="w-full bg-navy hover:bg-navy-hover text-white font-semibold py-4 rounded-full flex items-center justify-center gap-2 text-base transition-colors"
+                    className="w-full bg-navy hover:bg-navy-hover text-white font-semibold py-4 rounded-full flex items-center justify-center gap-2 text-lg transition-colors"
                   >
-                    <span>{t('navigation.getStarted')}</span>
+                    <span>{startFreeLabel}</span>
                     <ArrowRight className="w-5 h-5" />
                   </button>
                 )}

--- a/src/components/AffiliatePartner.tsx
+++ b/src/components/AffiliatePartner.tsx
@@ -92,21 +92,21 @@ export const AffiliatePartner: React.FC = () => {
   return (
     <div className="min-h-screen bg-porcelain font-instrument">
       {/* Hero Section */}
-      <section className="pt-32 sm:pt-40 lg:pt-44 pb-16 sm:pb-20 px-6 sm:px-8">
+      <section className="pt-28 sm:pt-32 lg:pt-36 pb-8 sm:pb-10 px-6 sm:px-8">
         <div className="max-w-6xl mx-auto">
-          <div className="grid lg:grid-cols-[2fr_1fr] gap-10 lg:gap-12 items-center">
+          <div className="grid lg:grid-cols-[2fr_1fr] gap-8 lg:gap-12 items-center">
             {/* Text column */}
-            <div className="space-y-6 sm:space-y-8 text-center lg:text-left">
-              <h1 className="font-general font-bold text-[2rem] leading-[1.1] sm:text-5xl lg:text-6xl sm:leading-tight text-navy">
+            <div className="space-y-5 sm:space-y-7 text-center lg:text-left">
+              <h1 className="font-general font-bold text-[2rem] leading-[1.1] sm:text-5xl lg:text-6xl sm:leading-[1.08] text-navy">
                 {t('affiliate.hero.title')}
               </h1>
 
-              <p className="text-base sm:text-lg lg:text-xl text-slate-blue max-w-3xl mx-auto lg:mx-0 leading-relaxed">
+              <p className="text-base sm:text-lg lg:text-xl text-slate-blue max-w-2xl mx-auto lg:mx-0 leading-relaxed">
                 {t('affiliate.hero.subtitle')}
               </p>
 
               {/* CTAs */}
-              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center lg:justify-start pt-2 sm:pt-4">
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center lg:justify-start pt-1 sm:pt-2">
                 <button
                   onClick={handlePartnerCTA}
                   className="group text-white font-semibold py-4 px-8 rounded-full bg-navy hover:bg-navy-hover transition-all duration-300 hover:shadow-xl hover:scale-[1.02] flex items-center justify-center space-x-2"
@@ -123,14 +123,14 @@ export const AffiliatePartner: React.FC = () => {
               </div>
             </div>
 
-            {/* Phone mockup column */}
-            <div className="flex justify-center lg:justify-end">
+            {/* Phone mockup column — desktop only */}
+            <div className="hidden lg:flex justify-center lg:justify-end">
               <img
                 src="/whatsapp phone mock.png"
                 alt="VoiceLink WhatsApp conversation showing CRM updates from voice notes"
                 style={{
                   width: 'auto',
-                  height: 'clamp(364px, 65vh, 624px)',
+                  height: 'clamp(320px, 46vh, 500px)',
                   transform: 'rotate(5deg)',
                   filter: 'drop-shadow(0 12px 20px rgba(0, 0, 0, 0.22)) drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15))',
                 }}
@@ -142,22 +142,25 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* How It Works */}
-      <section className="py-16 sm:py-20 px-6 sm:px-8 bg-white/50">
+      <section className="pt-2 sm:pt-4 pb-16 sm:pb-24 px-6 sm:px-8">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-10 sm:mb-16">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-8 sm:mb-12">
             {t('affiliate.howItWorks.title')}
           </h2>
 
-          <div className="grid sm:grid-cols-3 gap-10 sm:gap-8">
+          <div className="grid sm:grid-cols-3 gap-5 sm:gap-6">
             {[1, 2, 3].map((step) => (
-              <div key={step} className="text-center space-y-3 sm:space-y-4">
-                <div className="inline-flex items-center justify-center w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy text-white font-bold text-lg">
+              <div
+                key={step}
+                className="group relative bg-white rounded-2xl border border-navy/[0.07] shadow-sm p-6 sm:p-8 transition-all duration-300 hover:shadow-lg hover:-translate-y-1"
+              >
+                <div className="flex items-center justify-center w-12 h-12 rounded-2xl bg-navy text-white font-general font-bold text-xl mb-5 shadow-sm">
                   {step}
                 </div>
-                <h3 className="font-general font-semibold text-navy text-base sm:text-lg">
+                <h3 className="font-general font-semibold text-navy text-lg mb-2">
                   {t(`affiliate.howItWorks.step${step}.title`)}
                 </h3>
-                <p className="text-slate-blue text-sm leading-relaxed max-w-xs mx-auto">
+                <p className="text-slate-blue text-[15px] leading-relaxed">
                   {t(`affiliate.howItWorks.step${step}.description`)}
                 </p>
               </div>
@@ -167,22 +170,25 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Why Partner */}
-      <section className="py-16 sm:py-20 px-6 sm:px-8">
+      <section className="py-14 sm:py-20 px-6 sm:px-8">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-10 sm:mb-16">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-8 sm:mb-14">
             {t('affiliate.whyPartner.title')}
           </h2>
 
-          <div className="grid md:grid-cols-3 gap-5 sm:gap-8">
+          <div className="grid md:grid-cols-3 gap-5 sm:gap-6">
             {[1, 2, 3].map((item) => (
-              <div key={item} className="bg-white rounded-2xl p-6 sm:p-8 border border-navy/10">
-                <div className="w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy/10 flex items-center justify-center mb-4">
-                  <CheckCircle className="w-6 h-6 text-navy" />
+              <div
+                key={item}
+                className="group bg-white rounded-2xl p-6 sm:p-8 border border-navy/[0.07] shadow-sm transition-all duration-300 hover:shadow-lg hover:-translate-y-1"
+              >
+                <div className="w-12 h-12 rounded-2xl bg-navy/[0.06] flex items-center justify-center mb-5 transition-colors duration-300 group-hover:bg-navy/10">
+                  <CheckCircle className="w-6 h-6 text-navy" strokeWidth={1.75} />
                 </div>
-                <h3 className="font-general font-semibold text-navy text-base sm:text-lg mb-2 sm:mb-3">
+                <h3 className="font-general font-semibold text-navy text-lg mb-2">
                   {t(`affiliate.whyPartner.point${item}.title`)}
                 </h3>
-                <p className="text-slate-blue text-sm leading-relaxed">
+                <p className="text-slate-blue text-[15px] leading-relaxed">
                   {t(`affiliate.whyPartner.point${item}.description`)}
                 </p>
               </div>
@@ -192,9 +198,9 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Program Details Accordion */}
-      <section className="pt-12 sm:pt-16 pb-16 sm:pb-20 px-6 sm:px-8 bg-white/50">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-3 sm:mb-4">
+      <section className="py-14 sm:py-20 px-6 sm:px-8">
+        <div className="max-w-3xl mx-auto">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-3 sm:mb-4">
             {t('affiliate.accordion.title')}
           </h2>
           <p className="text-center text-slate-blue text-sm sm:text-base mb-8 sm:mb-12 max-w-2xl mx-auto">
@@ -205,29 +211,33 @@ export const AffiliatePartner: React.FC = () => {
             {accordionItems.map((item, index) => (
               <div
                 key={index}
-                className="border border-navy/15 rounded-xl overflow-hidden transition-all duration-200"
+                className="bg-white rounded-2xl border border-navy/[0.07] shadow-sm overflow-hidden"
               >
                 <button
                   onClick={() => setActiveAccordion(activeAccordion === index ? null : index)}
-                  className="w-full flex items-center justify-between p-5 sm:p-6 hover:bg-navy/5 transition-colors text-left"
+                  className="w-full flex items-center justify-between px-5 py-4 sm:px-6 sm:py-5 text-left gap-4 hover:bg-navy/[0.015] transition-colors duration-150"
                 >
-                  <h3 className="font-semibold text-navy text-base sm:text-lg pr-4">
+                  <h3 className="font-instrument font-semibold text-[15px] sm:text-base text-navy leading-snug pr-2">
                     {t(item.titleKey)}
                   </h3>
                   <ChevronDown
-                    className={`w-5 h-5 text-navy flex-shrink-0 transition-transform duration-300 ${
+                    className={`w-4 h-4 sm:w-5 sm:h-5 text-navy/40 flex-shrink-0 transition-transform duration-300 ${
                       activeAccordion === index ? 'rotate-180' : ''
                     }`}
                   />
                 </button>
 
-                {activeAccordion === index && (
-                  <div className="px-6 pb-6 border-t border-navy/10 bg-navy/2">
-                    <div className="text-slate-blue text-sm leading-relaxed space-y-3 whitespace-pre-wrap">
+                <div
+                  className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+                    activeAccordion === index ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                  }`}
+                >
+                  <div className="overflow-hidden min-h-0">
+                    <div className="px-5 pb-5 sm:px-6 sm:pb-6 pt-1 font-instrument text-[14px] sm:text-[15px] text-slate-blue leading-relaxed whitespace-pre-wrap">
                       {t(item.contentKey)}
                     </div>
                   </div>
-                )}
+                </div>
               </div>
             ))}
           </div>
@@ -235,18 +245,18 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Conversion Section */}
-      <section className="py-16 sm:py-20 px-6 sm:px-8" id="affiliate-form-section">
+      <section className="py-14 sm:py-20 px-6 sm:px-8" id="affiliate-form-section">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-3 sm:mb-4">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-3 sm:mb-4">
             {t('affiliate.conversion.title')}
           </h2>
-          <p className="text-center text-slate-blue text-sm sm:text-base mb-10 sm:mb-16 max-w-2xl mx-auto">
+          <p className="text-center text-slate-blue text-sm sm:text-base mb-10 sm:mb-14 max-w-2xl mx-auto">
             {t('affiliate.conversion.subtitle')}
           </p>
 
-          <div className="grid md:grid-cols-2 gap-10 md:gap-12">
+          <div className="grid md:grid-cols-2 gap-5 sm:gap-6 items-start">
             {/* Form Column */}
-            <div>
+            <div className="bg-white rounded-2xl border border-navy/[0.07] shadow-sm p-6 sm:p-8">
               <h3 className="font-general font-semibold text-lg sm:text-xl text-navy mb-5 sm:mb-6">
                 {t('affiliate.conversion.form.title')}
               </h3>
@@ -359,7 +369,7 @@ export const AffiliatePartner: React.FC = () => {
             </div>
 
             {/* Calendly Column */}
-            <div>
+            <div className="bg-white rounded-2xl border border-navy/[0.07] shadow-sm p-6 sm:p-8">
               <h3 className="font-general font-semibold text-lg sm:text-xl text-navy mb-5 sm:mb-6">
                 {t('affiliate.conversion.calendly.title')}
               </h3>
@@ -374,7 +384,7 @@ export const AffiliatePartner: React.FC = () => {
                 <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
               </button>
 
-              <div className="mt-6 sm:mt-8 p-5 sm:p-6 bg-navy/5 rounded-2xl border border-navy/10">
+              <div className="mt-6 sm:mt-8 pt-6 border-t border-navy/[0.07]">
                 <p className="text-sm text-navy/60 leading-relaxed">
                   {t('affiliate.conversion.calendly.contactBefore')}
                   <a

--- a/src/components/AffiliatePartner.tsx
+++ b/src/components/AffiliatePartner.tsx
@@ -92,7 +92,7 @@ export const AffiliatePartner: React.FC = () => {
   return (
     <div className="min-h-screen bg-porcelain font-instrument">
       {/* Hero Section */}
-      <section className="pt-28 sm:pt-32 lg:pt-36 pb-8 sm:pb-10 px-6 sm:px-8">
+      <section className="pt-28 sm:pt-32 lg:pt-36 pb-6 sm:pb-8 px-6 sm:px-8">
         <div className="max-w-6xl mx-auto">
           <div className="grid lg:grid-cols-[2fr_1fr] gap-8 lg:gap-12 items-center">
             {/* Text column */}
@@ -142,9 +142,9 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* How It Works */}
-      <section className="pt-2 sm:pt-4 pb-16 sm:pb-24 px-6 sm:px-8">
+      <section className="pt-2 sm:pt-4 pb-8 sm:pb-12 px-6 sm:px-8">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-8 sm:mb-12">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-6 sm:mb-8">
             {t('affiliate.howItWorks.title')}
           </h2>
 
@@ -170,9 +170,9 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Why Partner */}
-      <section className="py-14 sm:py-20 px-6 sm:px-8">
+      <section className="py-8 sm:py-10 px-6 sm:px-8">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-8 sm:mb-14">
+          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-6 sm:mb-8">
             {t('affiliate.whyPartner.title')}
           </h2>
 
@@ -198,12 +198,12 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Program Details Accordion */}
-      <section className="py-14 sm:py-20 px-6 sm:px-8">
+      <section className="py-8 sm:py-10 px-6 sm:px-8">
         <div className="max-w-3xl mx-auto">
           <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-3 sm:mb-4">
             {t('affiliate.accordion.title')}
           </h2>
-          <p className="text-center text-slate-blue text-sm sm:text-base mb-8 sm:mb-12 max-w-2xl mx-auto">
+          <p className="text-center text-slate-blue text-sm sm:text-base mb-6 sm:mb-8 max-w-2xl mx-auto">
             {t('affiliate.accordion.subtitle')}
           </p>
 
@@ -245,12 +245,12 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Conversion Section */}
-      <section className="py-14 sm:py-20 px-6 sm:px-8" id="affiliate-form-section">
+      <section className="py-8 sm:py-10 px-6 sm:px-8" id="affiliate-form-section">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-center font-general font-bold text-3xl sm:text-4xl md:text-5xl leading-[1.15] text-navy mb-3 sm:mb-4">
             {t('affiliate.conversion.title')}
           </h2>
-          <p className="text-center text-slate-blue text-sm sm:text-base mb-10 sm:mb-14 max-w-2xl mx-auto">
+          <p className="text-center text-slate-blue text-sm sm:text-base mb-7 sm:mb-9 max-w-2xl mx-auto">
             {t('affiliate.conversion.subtitle')}
           </p>
 

--- a/src/components/AffiliatePartner.tsx
+++ b/src/components/AffiliatePartner.tsx
@@ -92,21 +92,21 @@ export const AffiliatePartner: React.FC = () => {
   return (
     <div className="min-h-screen bg-porcelain font-instrument">
       {/* Hero Section */}
-      <section className="pt-44 pb-20 px-6 sm:px-8">
+      <section className="pt-32 sm:pt-40 lg:pt-44 pb-16 sm:pb-20 px-6 sm:px-8">
         <div className="max-w-6xl mx-auto">
-          <div className="grid lg:grid-cols-[2fr_1fr] gap-12 items-center">
+          <div className="grid lg:grid-cols-[2fr_1fr] gap-10 lg:gap-12 items-center">
             {/* Text column */}
-            <div className="space-y-8 text-center lg:text-left">
-              <h1 className="font-general font-bold text-4xl sm:text-5xl lg:text-6xl leading-tight text-navy">
+            <div className="space-y-6 sm:space-y-8 text-center lg:text-left">
+              <h1 className="font-general font-bold text-[2rem] leading-[1.1] sm:text-5xl lg:text-6xl sm:leading-tight text-navy">
                 {t('affiliate.hero.title')}
               </h1>
 
-              <p className="text-lg sm:text-xl text-slate-blue max-w-3xl mx-auto lg:mx-0">
+              <p className="text-base sm:text-lg lg:text-xl text-slate-blue max-w-3xl mx-auto lg:mx-0 leading-relaxed">
                 {t('affiliate.hero.subtitle')}
               </p>
 
               {/* CTAs */}
-              <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start pt-4">
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center lg:justify-start pt-2 sm:pt-4">
                 <button
                   onClick={handlePartnerCTA}
                   className="group text-white font-semibold py-4 px-8 rounded-full bg-navy hover:bg-navy-hover transition-all duration-300 hover:shadow-xl hover:scale-[1.02] flex items-center justify-center space-x-2"
@@ -142,22 +142,22 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* How It Works */}
-      <section className="py-20 px-6 sm:px-8 bg-white/50">
+      <section className="py-16 sm:py-20 px-6 sm:px-8 bg-white/50">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl text-navy mb-16">
+          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-10 sm:mb-16">
             {t('affiliate.howItWorks.title')}
           </h2>
 
-          <div className="grid md:grid-cols-4 gap-8">
-            {[1, 2, 3, 4].map((step) => (
-              <div key={step} className="text-center space-y-4">
-                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-navy text-white font-bold text-lg">
+          <div className="grid sm:grid-cols-3 gap-10 sm:gap-8">
+            {[1, 2, 3].map((step) => (
+              <div key={step} className="text-center space-y-3 sm:space-y-4">
+                <div className="inline-flex items-center justify-center w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy text-white font-bold text-lg">
                   {step}
                 </div>
-                <h3 className="font-general font-semibold text-navy text-lg">
+                <h3 className="font-general font-semibold text-navy text-base sm:text-lg">
                   {t(`affiliate.howItWorks.step${step}.title`)}
                 </h3>
-                <p className="text-slate-blue text-sm">
+                <p className="text-slate-blue text-sm leading-relaxed max-w-xs mx-auto">
                   {t(`affiliate.howItWorks.step${step}.description`)}
                 </p>
               </div>
@@ -167,19 +167,19 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Why Partner */}
-      <section className="py-20 px-6 sm:px-8">
+      <section className="py-16 sm:py-20 px-6 sm:px-8">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl text-navy mb-16">
+          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-10 sm:mb-16">
             {t('affiliate.whyPartner.title')}
           </h2>
 
-          <div className="grid md:grid-cols-3 gap-8">
+          <div className="grid md:grid-cols-3 gap-5 sm:gap-8">
             {[1, 2, 3].map((item) => (
-              <div key={item} className="bg-white rounded-2xl p-8 border border-navy/10">
-                <div className="w-12 h-12 rounded-full bg-navy/10 flex items-center justify-center mb-4">
+              <div key={item} className="bg-white rounded-2xl p-6 sm:p-8 border border-navy/10">
+                <div className="w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy/10 flex items-center justify-center mb-4">
                   <CheckCircle className="w-6 h-6 text-navy" />
                 </div>
-                <h3 className="font-general font-semibold text-navy text-lg mb-3">
+                <h3 className="font-general font-semibold text-navy text-base sm:text-lg mb-2 sm:mb-3">
                   {t(`affiliate.whyPartner.point${item}.title`)}
                 </h3>
                 <p className="text-slate-blue text-sm leading-relaxed">
@@ -192,12 +192,12 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Program Details Accordion */}
-      <section className="py-20 px-6 sm:px-8 bg-white/50">
+      <section className="pt-12 sm:pt-16 pb-16 sm:pb-20 px-6 sm:px-8 bg-white/50">
         <div className="max-w-4xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl text-navy mb-4">
+          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-3 sm:mb-4">
             {t('affiliate.accordion.title')}
           </h2>
-          <p className="text-center text-slate-blue mb-12 max-w-2xl mx-auto">
+          <p className="text-center text-slate-blue text-sm sm:text-base mb-8 sm:mb-12 max-w-2xl mx-auto">
             {t('affiliate.accordion.subtitle')}
           </p>
 
@@ -209,9 +209,9 @@ export const AffiliatePartner: React.FC = () => {
               >
                 <button
                   onClick={() => setActiveAccordion(activeAccordion === index ? null : index)}
-                  className="w-full flex items-center justify-between p-6 hover:bg-navy/5 transition-colors text-left"
+                  className="w-full flex items-center justify-between p-5 sm:p-6 hover:bg-navy/5 transition-colors text-left"
                 >
-                  <h3 className="font-semibold text-navy text-lg pr-4">
+                  <h3 className="font-semibold text-navy text-base sm:text-lg pr-4">
                     {t(item.titleKey)}
                   </h3>
                   <ChevronDown
@@ -235,16 +235,19 @@ export const AffiliatePartner: React.FC = () => {
       </section>
 
       {/* Conversion Section */}
-      <section className="py-20 px-6 sm:px-8" id="affiliate-form-section">
+      <section className="py-16 sm:py-20 px-6 sm:px-8" id="affiliate-form-section">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-center font-general font-bold text-3xl sm:text-4xl text-navy mb-16">
+          <h2 className="text-center font-general font-bold text-2xl sm:text-3xl lg:text-4xl text-navy mb-3 sm:mb-4">
             {t('affiliate.conversion.title')}
           </h2>
+          <p className="text-center text-slate-blue text-sm sm:text-base mb-10 sm:mb-16 max-w-2xl mx-auto">
+            {t('affiliate.conversion.subtitle')}
+          </p>
 
-          <div className="grid md:grid-cols-2 gap-12">
+          <div className="grid md:grid-cols-2 gap-10 md:gap-12">
             {/* Form Column */}
             <div>
-              <h3 className="font-general font-semibold text-xl text-navy mb-6">
+              <h3 className="font-general font-semibold text-lg sm:text-xl text-navy mb-5 sm:mb-6">
                 {t('affiliate.conversion.form.title')}
               </h3>
 
@@ -357,23 +360,30 @@ export const AffiliatePartner: React.FC = () => {
 
             {/* Calendly Column */}
             <div>
-              <h3 className="font-general font-semibold text-xl text-navy mb-6">
+              <h3 className="font-general font-semibold text-lg sm:text-xl text-navy mb-5 sm:mb-6">
                 {t('affiliate.conversion.calendly.title')}
               </h3>
-              <p className="text-slate-blue text-sm mb-6">
+              <p className="text-slate-blue text-sm sm:text-base leading-relaxed mb-6">
                 {t('affiliate.conversion.calendly.subtitle')}
               </p>
               <button
                 onClick={handleCalendlyClick}
-                className="w-full group border-2 border-navy text-navy font-semibold py-4 px-8 rounded-full transition-all duration-300 hover:scale-[1.02] hover:bg-navy/5 flex items-center justify-center space-x-2 text-base"
+                className="w-full group border-2 border-navy text-navy font-semibold py-3.5 sm:py-4 px-6 sm:px-8 rounded-full transition-all duration-300 hover:scale-[1.02] hover:bg-navy/5 flex items-center justify-center space-x-2 text-sm sm:text-base"
               >
                 <span>{t('affiliate.conversion.calendly.cta')}</span>
                 <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
               </button>
 
-              <div className="mt-8 p-6 bg-navy/5 rounded-2xl border border-navy/10">
+              <div className="mt-6 sm:mt-8 p-5 sm:p-6 bg-navy/5 rounded-2xl border border-navy/10">
                 <p className="text-sm text-navy/60 leading-relaxed">
-                  {t('affiliate.conversion.calendly.info')}
+                  {t('affiliate.conversion.calendly.contactBefore')}
+                  <a
+                    href="mailto:voicelink@finitsolutions.be"
+                    className="font-semibold text-navy hover:underline"
+                  >
+                    voicelink@finitsolutions.be
+                  </a>
+                  {t('affiliate.conversion.calendly.contactAfter')}
                 </p>
               </div>
             </div>

--- a/src/components/GettingStarted.tsx
+++ b/src/components/GettingStarted.tsx
@@ -61,7 +61,7 @@ export function GettingStarted() {
   return (
     <div className="min-h-screen bg-porcelain relative font-instrument">
       {/* ───────── HERO ───────── */}
-      <section className="pt-28 pb-10 md:pt-32 md:pb-14">
+      <section className="pt-4 pb-6 md:pt-6 md:pb-8">
         <div className="max-w-5xl mx-auto px-6">
           <button
             onClick={() => navigate(withUTM('/'))}
@@ -102,9 +102,9 @@ export function GettingStarted() {
       </section>
 
       {/* ───────── STEPS ───────── */}
-      <section className="pb-16 md:pb-20">
+      <section className="pb-6 md:pb-8">
         <div className="max-w-5xl mx-auto px-6">
-          <p className="text-navy/70 text-base md:text-lg mb-8 max-w-2xl">
+          <p className="text-navy/70 text-base md:text-lg mb-6 max-w-2xl">
             {t('gettingStartedPage.steps.intro')}
           </p>
 
@@ -161,24 +161,16 @@ export function GettingStarted() {
       </section>
 
       {/* ───────── HOW IT WORKS ───────── */}
-      <section className="pb-16 md:pb-20">
+      <section className="pb-6 md:pb-8">
         <div className="max-w-7xl mx-auto px-6">
-          <div className="text-center mb-8 md:mb-12">
-            <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.15] text-navy mb-3 md:mb-4">
-              {t('howItWorks.title')}
-            </h2>
-            <p className="text-lg md:text-xl font-instrument font-medium text-navy/60 max-w-3xl mx-auto">
-              {t('howItWorks.subtitle')}
-            </p>
-          </div>
           <HowItWorksDemo />
         </div>
       </section>
 
       {/* ───────── EXAMPLES ───────── */}
-      <section className="pb-16 md:pb-20">
+      <section className="pb-6 md:pb-8">
         <div className="max-w-5xl mx-auto px-6">
-          <div className="max-w-2xl mb-8">
+          <div className="max-w-2xl mb-6">
             <div className="flex items-center gap-2.5 text-navy/65 mb-3">
               <Mic className="w-4 h-4" />
               <span className="text-xs uppercase tracking-widest font-semibold">
@@ -220,9 +212,9 @@ export function GettingStarted() {
       </section>
 
       {/* ───────── TIPS ───────── */}
-      <section className="pb-16 md:pb-20">
+      <section className="pb-6 md:pb-8">
         <div className="max-w-5xl mx-auto px-6">
-          <div className="max-w-2xl mb-8">
+          <div className="max-w-2xl mb-6">
             <div className="flex items-center gap-2.5 text-navy/65 mb-3">
               <CheckCircle2 className="w-4 h-4" />
               <span className="text-xs uppercase tracking-widest font-semibold">
@@ -254,10 +246,10 @@ export function GettingStarted() {
       </section>
 
       {/* ───────── FAQ ───────── */}
-      <section className="pb-14 md:pb-18">
+      <section className="pb-6 md:pb-8">
         <div className="max-w-5xl mx-auto px-6">
           <div className="max-w-3xl mx-auto">
-            <div className="flex items-center gap-3 mb-8">
+            <div className="flex items-center gap-3 mb-6">
               <div className="w-10 h-10 bg-navy/[0.08] rounded-xl flex items-center justify-center">
                 <HelpCircle className="w-5 h-5 text-navy/75" />
               </div>
@@ -303,7 +295,7 @@ export function GettingStarted() {
       </section>
 
       {/* ───────── CTA ───────── */}
-      <section className="pb-16 md:pb-24">
+      <section className="pb-8 md:pb-12">
         <div className="max-w-5xl mx-auto px-6">
           <div className="bg-navy rounded-2xl p-8 md:p-12 text-center">
             <div className="relative z-10">

--- a/src/components/HeroDemo.tsx
+++ b/src/components/HeroDemo.tsx
@@ -1,122 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { CheckCircle, Play, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
+import { CheckCircle, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { useI18n } from '../hooks/useI18n';
 import { trackCTAClick } from '../utils/analytics';
 import { withUTM } from '../utils/utm';
 import { usePageTransition } from '../hooks/usePageTransition';
 import { useIsCompactHero } from '../hooks/useBreakpoint';
-
-const typewriterPhrases = [
-  "to your CRM.",
-  "We handle the data.",
-  "Your CRM thinks.",
-];
-
-const TYPING_SPEED = 80;
-const DELETING_SPEED = 40;
-const PAUSE_DURATION = 2000;
-const UNDERLINE_DURATION = 400;
-
-const useTypewriter = (phrases: string[]) => {
-  const [currentPhraseIndex, setCurrentPhraseIndex] = useState(0);
-  const [displayedText, setDisplayedText] = useState("");
-  const [phase, setPhase] = useState<'typing' | 'drawing' | 'paused' | 'deleting'>('typing');
-  const [isDrawing, setIsDrawing] = useState(false);
-
-  useEffect(() => {
-    const currentPhrase = phrases[currentPhraseIndex];
-    let timer: ReturnType<typeof setTimeout>;
-
-    switch (phase) {
-      case 'typing':
-        if (displayedText.length < currentPhrase.length) {
-          timer = setTimeout(() => {
-            setDisplayedText(currentPhrase.slice(0, displayedText.length + 1));
-          }, TYPING_SPEED);
-        } else {
-          // Fully typed — start drawing underline
-          setIsDrawing(true);
-          setPhase('drawing');
-        }
-        break;
-
-      case 'drawing':
-        timer = setTimeout(() => {
-          setPhase('paused');
-        }, UNDERLINE_DURATION);
-        break;
-
-      case 'paused':
-        timer = setTimeout(() => {
-          setIsDrawing(false);
-          setPhase('deleting');
-        }, PAUSE_DURATION);
-        break;
-
-      case 'deleting':
-        if (displayedText.length > 0) {
-          timer = setTimeout(() => {
-            setDisplayedText((prev) => prev.slice(0, -1));
-          }, DELETING_SPEED);
-        } else {
-          // Move to next phrase and start typing
-          setCurrentPhraseIndex((prev) => (prev + 1) % phrases.length);
-          setPhase('typing');
-        }
-        break;
-    }
-
-    return () => clearTimeout(timer);
-  }, [displayedText, phase, currentPhraseIndex, phrases]);
-
-  return { displayedText, isDrawing, currentPhraseIndex };
-};
-
-/** Split text so the last word is wrapped for the underline SVG */
-const TypewriterText: React.FC<{ text: string; isDrawing: boolean }> = ({ text, isDrawing }) => {
-  // Find the last word boundary
-  const trimmed = text.trimEnd();
-  const lastSpaceIdx = trimmed.lastIndexOf(' ');
-  const beforeLast = lastSpaceIdx >= 0 ? trimmed.slice(0, lastSpaceIdx + 1) : '';
-  const lastWord = lastSpaceIdx >= 0 ? trimmed.slice(lastSpaceIdx + 1) : trimmed;
-
-  return (
-    <>
-      {beforeLast}
-      {lastWord && (
-        <span className="relative inline-block">
-          <span className="relative z-10">{lastWord}</span>
-          <svg
-            className="absolute -bottom-1 left-0 w-full h-[0.45em] z-0"
-            viewBox="0 0 120 20"
-            preserveAspectRatio="none"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M2 16Q50 6 118 10"
-              stroke="#2D3A5C"
-              strokeOpacity="0.22"
-              strokeWidth="12"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              pathLength="1"
-              style={{
-                strokeDasharray: 1,
-                strokeDashoffset: isDrawing ? 0 : 1,
-                opacity: isDrawing ? 1 : 0,
-                transition: isDrawing
-                  ? 'stroke-dashoffset 400ms ease-out, opacity 0ms'
-                  : 'opacity 0ms',
-              }}
-            />
-          </svg>
-        </span>
-      )}
-    </>
-  );
-};
 
 /** Waveform bars + italic voice quote — shared across all cards */
 /** Seeded pseudo-random for deterministic per-card waveforms */
@@ -1433,7 +1322,9 @@ export const CrmPreviewCards: React.FC = () => {
     const onScroll = () => {
       if (isArrowNavRef.current) return;
       const cardW = (el.firstElementChild as HTMLElement)?.offsetWidth || el.clientWidth;
-      const idx = Math.round(el.scrollLeft / (cardW + 16));
+      // When scrolled to the far right, snap to the last card so the progress bar hits 100%.
+      const atEnd = el.scrollLeft >= el.scrollWidth - el.clientWidth - 2;
+      const idx = atEnd ? TOTAL_CARDS - 1 : Math.round(el.scrollLeft / (cardW + 16));
       const clamped = Math.max(0, Math.min(TOTAL_CARDS - 1, idx));
       if (clamped !== currentCardIdxRef.current) {
         currentCardIdxRef.current = clamped;
@@ -1452,7 +1343,9 @@ export const CrmPreviewCards: React.FC = () => {
       if (isArrowNavRef.current) return;
       const cardW = (el.firstElementChild as HTMLElement)?.offsetWidth || 420;
       const gap = parseFloat(getComputedStyle(el).gap) || 20;
-      const idx = Math.round(el.scrollLeft / (cardW + gap));
+      // When scrolled to the far right, snap to the last card so the progress bar hits 100%.
+      const atEnd = el.scrollLeft >= el.scrollWidth - el.clientWidth - 2;
+      const idx = atEnd ? TOTAL_CARDS - 1 : Math.round(el.scrollLeft / (cardW + gap));
       const clamped = Math.max(0, Math.min(TOTAL_CARDS - 1, idx));
       if (clamped !== currentCardIdxRef.current) {
         currentCardIdxRef.current = clamped;
@@ -1503,8 +1396,8 @@ export const CrmPreviewCards: React.FC = () => {
     <div style={{ zoom }}>
     <div className="relative pb-4 md:pb-6" style={{ marginTop: '0' }}>
       <h2
-        className="font-general font-bold text-navy text-center mb-6 md:mb-8 mt-6 md:mt-0 max-w-[260px] mx-auto md:max-w-none"
-        style={{ fontSize: 'clamp(1.75rem, calc(1.2rem + 2vw), 3.25rem)', letterSpacing: '-0.02em' }}
+        className="font-general font-bold text-navy text-center leading-[1.15] mb-6 md:mb-8 mt-6 md:mt-0 max-w-[260px] mx-auto md:max-w-none text-3xl sm:text-4xl md:text-5xl 2xl:text-6xl"
+        style={{ letterSpacing: '-0.02em' }}
       >
         {t('hero.carouselTitle')}
       </h2>
@@ -1563,17 +1456,25 @@ export const CrmPreviewCards: React.FC = () => {
 export const HeroDemo: React.FC = () => {
   const { navigateWithTransition } = usePageTransition();
   const { t } = useI18n();
-  const { displayedText, isDrawing, currentPhraseIndex } = useTypewriter(typewriterPhrases);
-  const showTalkDot = currentPhraseIndex !== 0; // hide "." after "Talk" when "to your CRM." is active
   const isCompact = useIsCompactHero();
+
+  // Subtitle with inline Teamleader + WhatsApp logos (shared by both branches)
+  const subtitleLogos = (
+    <>
+      {t('hero.subtitle1_pre')}{' '}
+      <img src="/Logo_Teamleader_Default_CMYK.png" alt="Teamleader" className="inline-block h-[3.2em] w-auto align-middle -ml-1 -mr-2 my-[-1.1em]" style={{ clipPath: 'inset(0 6% 0 6%)', transform: 'translateY(-0.35em)' }} draggable={false} />{' '}
+      {t('hero.subtitle1_mid')}{' '}
+      <span className="inline-flex items-center gap-[0.25em] mx-1 align-[-0.3em] my-[-0.2em]"><img src="/whatsapp-green.svg" alt="WhatsApp" className="h-[1.35em] w-auto" draggable={false} /><span className="font-bold text-black text-[0.9em]">WhatsApp</span></span>{t('hero.subtitle1_post')}
+    </>
+  );
 
   return (
     <div className="w-full">
       {/* Hero Content — Fixed layout with absolute positioning */}
-      <section className="relative" style={isCompact ? { minHeight: '100svh', overflowX: 'clip' } : { height: '100svh', overflow: 'clip' }}>
-        {/* Mobile: Blue logo next to hamburger */}
-        <div className="md:hidden absolute top-3 right-[72px] z-20 pointer-events-none flex items-center" style={{ height: '44px' }}>
-          <img src="/Finit Voicelink Blue.svg" alt="VoiceLink" className="h-9 w-auto" />
+      <section className="relative" style={{ overflowX: 'clip' }}>
+        {/* Mobile: Blue logo top-left of hero (scrolls with section) */}
+        <div className="md:hidden absolute top-3 left-4 z-20 pointer-events-none flex items-center" style={{ height: '44px' }}>
+          <img src="/Finit Voicelink Blue.svg" alt="VoiceLink" className="h-10 w-auto" />
         </div>
 
         {/* Decorative corner waves — desktop (landscape) */}
@@ -1581,6 +1482,7 @@ export const HeroDemo: React.FC = () => {
           className="absolute inset-0 w-full h-full pointer-events-none hidden md:block hero-animate-waves"
           viewBox="0 0 1440 900"
           preserveAspectRatio="none"
+          overflow="visible"
           aria-hidden="true"
         >
           {/* ── Top-left corner ── */}
@@ -1593,171 +1495,78 @@ export const HeroDemo: React.FC = () => {
                L-10,370 C55,325 25,265 135,205 C235,150 175,65 218,-10 L205,-25 Z"
             fill="#7B8DB5"
           />
-          {/* ── Bottom-right corner ── vertical tangent at y=930, matched curvature with section below */}
-          <path
-            d="M1470,930 L1240,930 C1240,750 1200,690 1320,645 C1450,598 1400,540 1470,460 Z"
-            fill="#1A2D63"
-          />
-          <path
-            d="M1248,930 C1248,755 1205,693 1325,648 C1455,601 1405,543 1475,465
-               L1470,452 C1398,535 1448,595 1318,642 C1195,688 1232,750 1232,930 L1248,930 Z"
-            fill="#7B8DB5"
-          />
+          {/* Bottom-right corner is now rendered as one unit together with the
+              next section's corner — see Homepage.tsx "How It Works" section. */}
         </svg>
 
-        {/* Top-left corner — same desktop paths, cropped viewBox */}
-        <svg
-          className="absolute left-0 pointer-events-none block md:hidden hero-animate-waves"
-          style={{ top: '-8px' }}
-          width="128" height="240"
-          viewBox="-30 -30 255 480"
-          overflow="visible"
-          aria-hidden="true"
-        >
-          <path
-            d="M-30,-30 L220,-30 C170,60 230,140 130,200 C30,260 60,310 -30,360 L-30,430 Z"
-            fill="#1A2D63"
-          />
-          <path
-            d="M222,-55 C177,25 220,135 125,195 C30,255 30,318 -55,368
-               L-34,397 C31,352 30,272 140,212 C240,157 197,42 236,-25 L222,-55 Z"
-            fill="#7B8DB5"
-          />
-        </svg>
-        {/* Bottom-right corner — same desktop paths, cropped viewBox */}
-        <svg
-          className="absolute bottom-0 right-0 pointer-events-none block md:hidden"
-          style={{ bottom: '60px' }}
-          width="143" height="250"
-          viewBox="1183 440 285 500"
-          aria-hidden="true"
-        >
-          <path
-            d="M1470,940 L1240,940 C1240,750 1200,690 1320,645 C1450,598 1400,540 1470,460 Z"
-            fill="#1A2D63"
-          />
-          <path
-            d="M1248,940 C1248,755 1205,693 1325,648 C1455,601 1405,543 1475,465
-               L1470,452 C1398,535 1448,595 1318,642 C1195,688 1232,750 1232,940 L1248,940 Z"
-            fill="#7B8DB5"
-          />
-        </svg>
-
-        {/* ── COMPACT (mobile/tablet): text column + phone in normal flow ── */}
+        {/* ── COMPACT (mobile/tablet): single centered column ── */}
         {isCompact && (
-          <div className="relative z-20 flex flex-col items-center px-[4%] pb-4 md:pb-12" style={{ paddingTop: '20svh' }}>
-            <div className="w-full max-w-lg flex flex-col items-center text-center">
+          <div className="relative z-20 flex flex-col items-center px-[6%] pb-10" style={{ paddingTop: '13svh' }}>
+            <div className="w-full max-w-xl flex flex-col items-center text-center">
               <div className="overflow-visible hero-animate-heading">
-                <h1 className="font-general leading-[1] tracking-tight text-navy text-center" style={{ fontSize: 'clamp(1.7rem, calc(0.7rem + 3vw + 1.5vh), 3.2rem)' }}>
-                  <span className="font-bold" style={{ letterSpacing: '-0.025em', WebkitFontSmoothing: 'antialiased' }}>
-                    Just... Talk{showTalkDot ? '.' : ''}
-                  </span>
-                  <br />
-                  <span className="font-black italic">
-                    <TypewriterText text={displayedText} isDrawing={isDrawing} />
-                  </span>
-                  <span className="inline-block w-[3px] h-[1em] bg-[#1A2D63] ml-1 animate-pulse align-baseline" />
+                <h1 className="font-general font-black leading-[1.05] tracking-tight text-navy text-center" style={{ fontSize: 'clamp(1.9rem, calc(0.8rem + 4vw + 1.5vh), 3.4rem)' }}>
+                  {t('hero.staticTitle')}
                 </h1>
               </div>
-              <div className="w-full max-w-lg">
-                <div className="hero-animate-subtitle">
-                  <p className="font-instrument text-slate-blue leading-relaxed max-w-lg mx-auto text-center" style={{ fontSize: 'clamp(1rem, calc(0.7rem + 0.3vw + 0.35vh), 1.375rem)' }}>
-                    {t('hero.subtitle1_pre')}{' '}
-                    <img src="/Logo_Teamleader_Default_CMYK.png" alt="Teamleader" className="inline-block h-[3.2em] w-auto align-[-1em] -mx-2" style={{ clipPath: 'inset(0 6% 0 6%)' }} draggable={false} />{' '}
-                    {t('hero.subtitle1_mid')}{' '}
-                    <span className="inline-flex items-center gap-[0.25em] mx-1 align-[-0.3em]"><img src="/whatsapp-green.svg" alt="WhatsApp" className="h-[1.35em] w-auto" draggable={false} /><span className="font-bold text-black text-[0.9em]">WhatsApp</span></span>
-                    <span className="block" style={{ marginTop: '-0.7em', lineHeight: '1.5' }}>{t('hero.subtitle1_post')}</span>
-                  </p>
-                </div>
-                <div className="hero-animate-ctas" style={{ marginTop: 'clamp(0.75rem, calc(0.5rem + 1vh), 2rem)' }}>
-                  <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-                    <button onClick={() => { trackCTAClick('Get Started Free - Hero', '/'); navigateWithTransition(withUTM('/signup')); }} className="group bg-navy text-white font-medium rounded-full flex items-center justify-center gap-2 hover:bg-navy-hover transition-colors shadow-lg shadow-black/10 text-[13px] px-5 py-2.5">
-                      <span>{t('hero.getStartedFree')}</span>
-                      <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                    </button>
-                    <button className="group border-2 border-navy text-navy font-medium rounded-full flex items-center justify-center gap-2 transition-colors hover:bg-navy/5 text-[13px] px-5 py-2.5" onClick={() => { trackCTAClick('Watch Demo - Hero', '/'); const el = document.getElementById('how-it-works'); if (el) window.scrollTo({ top: el.offsetTop - 10, behavior: 'smooth' }); }}>
-                      <Play className="w-4 h-4" />
-                      <span>{t('hero.watchDemo')}</span>
-                    </button>
-                  </div>
-                </div>
-                <div className="hero-animate-checks" style={{ marginTop: 'clamp(0.5rem, calc(0.35rem + 0.6vh), 1.25rem)' }}>
-                  <div className="flex sm:flex-row flex-col items-start justify-start gap-x-6 gap-y-1.5 text-sm text-muted-blue w-fit mx-auto">
-                    <div className="flex items-center space-x-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.oneClickSetup')}</span></div>
-                    <span className="hidden sm:inline">·</span>
-                    <div className="flex items-center space-x-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.whatsappSetup')}</span></div>
-                  </div>
+              <div className="hero-animate-subtitle mt-4">
+                <p className="font-instrument text-slate-blue leading-[1.7] max-w-2xl mx-auto text-center" style={{ fontSize: 'clamp(1rem, calc(0.7rem + 0.3vw + 0.35vh), 1.375rem)' }}>
+                  {subtitleLogos}
+                </p>
+              </div>
+              <div className="hero-animate-ctas mt-6">
+                <div className="flex flex-row gap-3 justify-center">
+                  <button onClick={() => { trackCTAClick('Get Started Free - Hero', '/'); navigateWithTransition(withUTM('/signup')); }} className="group bg-navy text-white font-medium rounded-full flex items-center justify-center gap-2 hover:bg-navy-hover transition-colors shadow-lg shadow-black/10 text-[15px] px-6 py-3">
+                    <span>{t('hero.getStartedFree')}</span>
+                    <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                  </button>
+                  <button className="group border-2 border-navy text-navy font-medium rounded-full flex items-center justify-center gap-2 transition-colors hover:bg-navy/5 text-[15px] px-6 py-3" onClick={() => { trackCTAClick('How to Install - Hero', '/'); navigateWithTransition(withUTM('/getting-started')); }}>
+                    <span>{t('hero.howToInstall')}</span>
+                  </button>
                 </div>
               </div>
-              <div className="pointer-events-none" style={{ width: 'min(460px, 86vw)', marginTop: 'clamp(1rem, 3vh, 2.5rem)' }}>
-                <div className="flex items-start justify-center hero-animate-phone-bottom">
-                  <img src="/whatsapp phone mock.png" alt="VoiceLink WhatsApp conversation showing CRM updates from voice notes" style={{ width: 'min(460px, 97vw)', height: 'auto', transform: 'rotate(5deg)', filter: 'drop-shadow(0 12px 20px rgba(0, 0, 0, 0.22)) drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15))' }} draggable={false} />
+              <div className="hero-animate-checks mt-8">
+                <div className="inline-flex flex-col sm:flex-row flex-wrap items-start sm:items-center justify-center gap-x-6 gap-y-2 text-sm text-muted-blue">
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletSetup')}</span></div>
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletNoTech')}</span></div>
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletNoCard')}</span></div>
                 </div>
               </div>
             </div>
           </div>
         )}
 
-        {/* ── DESKTOP: centered flex row, text left + phone right ── */}
+        {/* ── DESKTOP: single centered column ── */}
         {!isCompact && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center" style={{ padding: '6vh 6vw 0', gap: 'clamp(0.25rem, 0.5vw, 1rem)' }}>
-            {/* Text column */}
-            <div className="flex flex-col items-start text-left flex-1 min-w-0 max-w-[540px] xl:max-w-[660px] 2xl:max-w-[800px]">
+          <div className="relative z-10 flex flex-col items-center justify-center text-center" style={{ padding: '18vh 6vw 7vh' }}>
+            <div className="flex flex-col items-center text-center max-w-[820px]">
               <div className="overflow-visible hero-animate-heading w-full">
-                <h1 className="font-general leading-[1] tracking-tight text-navy text-left" style={{ fontSize: 'clamp(2.5rem, calc(1.8rem + 1.2vw + 1.5vh), 6rem)' }}>
-                  <span className="font-bold" style={{ letterSpacing: '-0.025em', WebkitFontSmoothing: 'antialiased' }}>
-                    Just... Talk{showTalkDot ? '.' : ''}
-                  </span>
-                  <br />
-                  <span className="font-black italic">
-                    <TypewriterText text={displayedText} isDrawing={isDrawing} />
-                  </span>
-                  <span className="inline-block w-[3px] h-[1em] bg-[#1A2D63] ml-1 animate-pulse align-baseline" />
+                <h1 className="font-general font-black leading-[1.05] tracking-tight text-navy text-center" style={{ fontSize: 'clamp(2.5rem, calc(1.8rem + 1.2vw + 1.5vh), 5.5rem)' }}>
+                  {t('hero.staticTitle')}
                 </h1>
               </div>
               <div className="hero-animate-subtitle w-full" style={{ marginTop: 'clamp(0.75rem, calc(0.5rem + 1vh), 1.5rem)' }}>
-                <p className="font-instrument text-slate-blue leading-relaxed text-left max-w-[520px]" style={{ fontSize: 'clamp(1rem, calc(0.7rem + 0.3vw + 0.35vh), 1.375rem)' }}>
-                  {t('hero.subtitle1_pre')}{' '}
-                  <img src="/Logo_Teamleader_Default_CMYK.png" alt="Teamleader" className="inline-block h-[3.2em] w-auto align-[-1em] -mx-2" style={{ clipPath: 'inset(0 6% 0 6%)' }} draggable={false} />{' '}
-                  {t('hero.subtitle1_mid')}{' '}
-                  <span className="inline-flex items-center gap-[0.25em] mx-1 align-[-0.3em]"><img src="/whatsapp-green.svg" alt="WhatsApp" className="h-[1.35em] w-auto" draggable={false} /><span className="font-bold text-black text-[0.9em]">WhatsApp</span></span>{' '}
-                  {t('hero.subtitle1_post')}
+                <p className="font-instrument text-slate-blue leading-[1.7] text-center max-w-2xl mx-auto" style={{ fontSize: 'clamp(1rem, calc(0.7rem + 0.3vw + 0.35vh), 1.375rem)' }}>
+                  {subtitleLogos}
                 </p>
               </div>
               <div className="hero-animate-ctas w-full" style={{ marginTop: 'clamp(0.75rem, calc(0.5rem + 1vh), 2rem)' }}>
-                <div className="flex flex-row gap-4 justify-start">
-                  <button onClick={() => { trackCTAClick('Get Started Free - Hero', '/'); navigateWithTransition(withUTM('/signup')); }} className="group bg-navy text-white font-medium rounded-full flex items-center justify-center gap-2 hover:bg-navy-hover transition-colors shadow-lg shadow-black/10 text-[15px] px-6 py-3">
+                <div className="flex flex-row gap-4 justify-center">
+                  <button onClick={() => { trackCTAClick('Get Started Free - Hero', '/'); navigateWithTransition(withUTM('/signup')); }} className="group bg-navy text-white font-medium rounded-full flex items-center justify-center gap-2 hover:bg-navy-hover transition-colors shadow-lg shadow-black/10 text-base md:text-[17px] px-7 py-3.5">
                     <span>{t('hero.getStartedFree')}</span>
                     <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
                   </button>
-                  <button className="group border-2 border-navy text-navy font-medium rounded-full flex items-center justify-center gap-2 transition-colors hover:bg-navy/5 text-[15px] px-6 py-3" onClick={() => { trackCTAClick('Watch Demo - Hero', '/'); const el = document.getElementById('how-it-works'); if (el) window.scrollTo({ top: el.offsetTop - 10, behavior: 'smooth' }); }}>
-                    <Play className="w-5 h-5" />
-                    <span>{t('hero.watchDemo')}</span>
+                  <button className="group border-2 border-navy text-navy font-medium rounded-full flex items-center justify-center gap-2 transition-colors hover:bg-navy/5 text-base md:text-[17px] px-7 py-3.5" onClick={() => { trackCTAClick('How to Install - Hero', '/'); navigateWithTransition(withUTM('/getting-started')); }}>
+                    <span>{t('hero.howToInstall')}</span>
                   </button>
                 </div>
               </div>
-              <div className="hero-animate-checks w-full" style={{ marginTop: 'clamp(0.5rem, calc(0.35rem + 0.6vh), 1.25rem)' }}>
-                <div className="flex flex-wrap items-center justify-start gap-x-6 gap-y-2 text-sm text-muted-blue">
-                  <div className="flex items-center space-x-2"><CheckCircle className="w-4 h-4 text-navy" /><span>{t('hero.oneClickSetup')}</span></div>
-                  <span className="hidden sm:inline">·</span>
-                  <div className="flex items-start space-x-2 max-w-[180px]"><CheckCircle className="w-4 h-4 text-navy mt-0.5 flex-shrink-0" /><span className="leading-snug whitespace-pre-line">{t('hero.whatsappSetup')}</span></div>
+              <div className="hero-animate-checks w-full mt-8">
+                <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-muted-blue">
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletSetup')}</span></div>
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletNoTech')}</span></div>
+                  <div className="flex items-center gap-2"><CheckCircle className="w-4 h-4 text-navy flex-shrink-0" /><span>{t('hero.bulletNoCard')}</span></div>
                 </div>
               </div>
-            </div>
-
-            {/* Phone */}
-            <div className="flex-shrink-0">
-              <img
-                src="/whatsapp phone mock.png"
-                alt="VoiceLink WhatsApp conversation showing CRM updates from voice notes"
-                style={{
-                  width: 'auto',
-                  height: 'clamp(540px, 92svh, 1020px)',
-                  transform: 'rotate(7deg)',
-                  filter: 'drop-shadow(0 12px 20px rgba(0, 0, 0, 0.22)) drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15))',
-                }}
-                draggable={false}
-              />
             </div>
           </div>
         )}

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
-import { Zap, MessageCircle, Play, ArrowRight, CheckCircle, ChevronDown, Star, PhoneOff, StickyNote, TrendingDown, Snowflake, Phone, Mail, Linkedin } from 'lucide-react';
+import { Play, ArrowRight, CheckCircle, ChevronDown, MicOff, StickyNote, CalendarX, ClipboardList, Phone, Mail, Linkedin } from 'lucide-react';
 import { HowItWorksDemo } from './HowItWorksDemo';
 import { HeroDemo, CrmPreviewCards } from './HeroDemo';
-import { UserGuidePreview } from './UserGuidePreview';
 import { PricingSection } from './PricingSection';
-import { LogoCarousel } from './ui/LogoCarousel';
 import { SectionDivider } from './ui/SectionDivider';
 import { ScrollAnimation } from './ui/ScrollAnimation';
 import { useConsent } from '../contexts/ConsentContext';
 import { useI18n } from '../hooks/useI18n';
-import { useNavigate } from 'react-router-dom';
 import { trackCTAClick } from '../utils/analytics';
-import { withUTM } from '../utils/utm';
-import { usePageTransition } from '../hooks/usePageTransition';
 
 interface HomepageProps {
   openContactModal: () => void;
@@ -109,8 +104,6 @@ const faqContentNl: React.ReactNode[] = [
 export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
   const { openSettings } = useConsent();
   const { t, currentLanguage } = useI18n();
-  const navigate = useNavigate();
-  const { navigateWithTransition } = usePageTransition();
   const [openFaq, setOpenFaq] = React.useState<number | null>(null);
 
   return (
@@ -121,52 +114,48 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
 
       {/* ───────── 4. HOW IT WORKS ───────── */}
       <section id="how-it-works" className="pt-4 md:pt-0 pb-4 2xl:pb-8 relative z-10 scroll-mt-24">
-        {/* Decorative corner — flows from hero bottom-right (desktop) */}
+        {/* Decorative corner — BOTH shapes as one unit, anchored to the
+            hero/section boundary (top-0) with a fixed vertical scale (height in
+            px, not %), so they never drift apart or shift when section heights
+            change on resize. Shape A bleeds up into the hero; shape B sits in
+            this section. Tune positions via the two translate() values. */}
         <svg
-          className="absolute inset-0 w-full h-full pointer-events-none hidden md:block"
+          className="absolute top-0 left-0 right-0 w-full pointer-events-none hidden md:block"
+          style={{ height: '900px' }}
           viewBox="0 0 1440 900"
           preserveAspectRatio="none"
+          overflow="visible"
           aria-hidden="true"
         >
-          <path
-            d="M1470,-30 L1239.5,-30 C1239.5,90 1225.5,115 1320.5,138 C1430.5,162 1415.5,176 1470,190 Z"
-            fill="#1A2D63"
-          />
-          <path
-            d="M1248,-30 C1248,87 1232.5,112 1326,136 C1435.5,159 1420.5,173 1476,186
-               L1471,198 C1410.5,183 1428.5,168 1319,145 C1218.5,123 1232,87 1232,-30 L1248,-30 Z"
-            fill="#7B8DB5"
-          />
-        </svg>
-        {/* Decorative corner — mobile/tablet top-right */}
-        <svg
-          className="absolute top-0 right-0 pointer-events-none block md:hidden"
-          style={{ top: '-70px' }}
-          width="128" height="115"
-          viewBox="1213 -30 255 230"
-          aria-hidden="true"
-        >
-          <path
-            d="M1470,-30 L1239.5,-30 C1239.5,90 1225.5,115 1320.5,138 C1430.5,162 1415.5,176 1470,190 Z"
-            fill="#1A2D63"
-          />
-          <path
-            d="M1248,-30 C1248,87 1232.5,112 1326,136 C1435.5,159 1420.5,173 1476,186
-               L1471,198 C1410.5,183 1428.5,168 1319,145 C1218.5,123 1232,87 1232,-30 L1248,-30 Z"
-            fill="#7B8DB5"
-          />
+          {/* Whole unit — move both shapes together with this one translate. */}
+          <g transform="translate(0, 100)">
+          {/* Shape A — upper blob, bleeds up into the hero */}
+          <g transform="translate(0, -680)">
+            <path
+              d="M1470,930 L1240,930 C1240,750 1200,690 1320,645 C1450,598 1400,540 1470,460 Z"
+              fill="#1A2D63"
+            />
+            <path
+              d="M1248,930 C1248,755 1205,693 1325,648 C1455,601 1405,543 1475,465
+                 L1470,452 C1398,535 1448,595 1318,642 C1195,688 1232,750 1232,930 L1248,930 Z"
+              fill="#7B8DB5"
+            />
+          </g>
+          {/* Shape B — lower corner, sits in this section */}
+          <g transform="translate(0, 250)">
+            <path
+              d="M1470,-30 L1239.5,-30 C1239.5,90 1225.5,115 1320.5,138 C1430.5,162 1415.5,176 1470,190 Z"
+              fill="#1A2D63"
+            />
+            <path
+              d="M1248,-30 C1248,87 1232.5,112 1326,136 C1435.5,159 1420.5,173 1476,186
+                 L1471,198 C1410.5,183 1428.5,168 1319,145 C1218.5,123 1232,87 1232,-30 L1248,-30 Z"
+              fill="#7B8DB5"
+            />
+          </g>
+          </g>
         </svg>
         <div className="max-w-7xl 2xl:max-w-screen-2xl mx-auto px-6">
-          <ScrollAnimation>
-            <div className="text-center mb-6 md:mb-10 2xl:mb-14">
-              <h2 className="font-general text-3xl sm:text-4xl md:text-5xl xl:text-6xl font-bold leading-[1.15] text-navy mb-2 md:mb-6">
-                {t('howItWorks.title')}
-              </h2>
-              <p className="text-lg md:text-xl xl:text-2xl font-instrument font-medium text-navy/60 max-w-3xl mx-auto">
-                {t('howItWorks.subtitle')}
-              </p>
-            </div>
-          </ScrollAnimation>
           <HowItWorksDemo />
         </div>
       </section>
@@ -176,10 +165,10 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
 
       {/* ───────── 3. PROBLEM AGITATION ───────── */}
       <section className="bg-navy py-6 md:py-8 relative z-10">
-        <div className="max-w-5xl mx-auto px-6">
+        <div className="max-w-6xl mx-auto px-6">
           <ScrollAnimation>
-            <div className="text-center mb-16 md:mb-20">
-              <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.15] text-white mb-5">
+            <div className="text-center mb-8 md:mb-10">
+              <h2 className="font-general text-3xl sm:text-4xl md:text-5xl 2xl:text-6xl font-bold leading-[1.15] text-white mb-5">
                 {t('problemAgitation.title')}
               </h2>
               <p className="text-lg md:text-xl font-instrument font-medium text-white/50 max-w-2xl mx-auto">
@@ -189,10 +178,10 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
           </ScrollAnimation>
           <div className="grid md:grid-cols-2 gap-5 md:gap-6">
             {([
-              { n: 1, Icon: PhoneOff },
+              { n: 1, Icon: MicOff },
               { n: 2, Icon: StickyNote },
-              { n: 3, Icon: TrendingDown },
-              { n: 4, Icon: Snowflake },
+              { n: 3, Icon: CalendarX },
+              { n: 4, Icon: ClipboardList },
             ]).map(({ n, Icon }) => (
               <ScrollAnimation key={n} delay={n * 100}>
                 <div
@@ -221,94 +210,8 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
         <CrmPreviewCards />
       </div>
 
-      {/* Divider: CRM Preview → User Guide Preview */}
+      {/* Divider: CRM Preview → Pricing (porcelain → porcelain) */}
       <SectionDivider fromColor="#FDFBF7" toColor="#FDFBF7" variant={0} />
-
-      {/* ───────── 5b. USER GUIDE PREVIEW ("Just say what happened") ───────── */}
-      <UserGuidePreview />
-
-      {/* Divider: User Guide Preview → Integrations */}
-      <SectionDivider fromColor="#FDFBF7" toColor="#FDFBF7" variant={3} />
-
-      {/* ───────── 6. INTEGRATIONS ───────── */}
-      <ScrollAnimation>
-        <section id="integrations" className="pt-2 pb-6 relative z-10 scroll-mt-24">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6">
-            <div className="text-center mb-12">
-              <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.15] text-navy mb-6 flex flex-col sm:flex-row items-center justify-center gap-0 sm:gap-x-3 -translate-x-6 translate-y-6 sm:translate-x-0 sm:translate-y-0 md:translate-x-6">
-                <span>{t('integrations.titleBefore')}</span>
-                <img
-                  src="/Logo_Teamleader_Default_CMYK.png"
-                  alt="Teamleader"
-                  className="h-28 md:h-32 lg:h-36 -mt-12 sm:-mt-2 md:-mt-6 lg:-mt-8 self-end md:translate-y-[5px] md:-translate-x-6"
-                />
-              </h2>
-              <button
-                onClick={() => { trackCTAClick('try_free_integrations', '/'); document.getElementById('pricing')?.scrollIntoView({ behavior: 'smooth', block: 'start' }); }}
-                className="relative z-10 bg-navy hover:bg-navy-hover text-white font-medium text-[15px] py-3.5 px-8 rounded-full transition-all duration-300 hover:shadow-xl hover:scale-[1.02] mb-8"
-              >
-                {t('integrations.tryForFree')}
-              </button>
-              <div className="flex flex-col items-start gap-3 text-base md:text-xl font-instrument font-medium text-navy w-fit mx-auto">
-                <span className="flex items-center gap-2.5"><span className="text-navy">✓</span> {t('integrations.bullet1')}</span>
-                <span className="flex items-center gap-2.5"><span className="text-navy">✓</span> {t('integrations.bullet2')}</span>
-                <span className="flex items-center gap-2.5"><span className="text-navy">✓</span> {t('integrations.bullet3')}</span>
-              </div>
-            </div>
-
-            <div className="text-center mt-6">
-              <p className="text-slate-blue mb-4 font-instrument max-w-xl mx-auto">{t('features.dontSeeYourCrm')}</p>
-              <button
-                onClick={() => { trackCTAClick('contact_for_custom', '/'); openContactModal(); }}
-                className="inline-flex items-center space-x-2 px-8 py-4 bg-white border border-navy/30 rounded-full shadow-lg hover:border-navy/50 hover:shadow-xl hover:scale-[1.02] transition-all group"
-              >
-                <span className="text-[15px] font-medium text-navy">{t('features.contactForCustom')}</span>
-                <MessageCircle className="w-4 h-4 text-navy/50 group-hover:text-navy transition-colors" />
-              </button>
-            </div>
-
-            <div className="text-center mt-10 pt-8 border-t border-navy/10">
-              <p className="text-slate-blue mb-4 font-instrument max-w-xl mx-auto">{t('features.partnerProgramPrompt')}</p>
-              <button
-                onClick={() => { trackCTAClick('partner_program', '/'); navigate(withUTM('/affiliate')); }}
-                className="inline-flex items-center space-x-2 px-8 py-4 bg-white border border-navy/30 rounded-full shadow-lg hover:border-navy/50 hover:shadow-xl hover:scale-[1.02] transition-all group"
-              >
-                <span className="text-[15px] font-medium text-navy">{t('features.partnerProgramCTA')}</span>
-                <ArrowRight className="w-4 h-4 text-navy/50 group-hover:text-navy group-hover:translate-x-1 transition-all" />
-              </button>
-            </div>
-          </div>
-        </section>
-      </ScrollAnimation>
-
-      {/* Divider: Integrations → Testimonials (porcelain → navy) */}
-      <SectionDivider fromColor="#FDFBF7" toColor="#1A2D63" variant={1} />
-
-      {/* ───────── 7. TESTIMONIALS (on navy bg) ───────── */}
-      <section className="py-10 relative z-10 bg-navy">
-        <div className="max-w-5xl mx-auto px-6">
-          <ScrollAnimation>
-            <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.15] text-white text-center mb-16">
-              {t('testimonials.title')}
-            </h2>
-          </ScrollAnimation>
-
-          <div className="grid md:grid-cols-2 gap-8">
-            {[1, 2].map((n) => (
-              <ScrollAnimation key={n} delay={n * 150}>
-                <div className="bg-white/10 backdrop-blur-sm rounded-2xl border border-white/10 p-8 hover:bg-white/15 transition-all duration-300">
-                  <p className="font-general text-lg md:text-xl font-semibold italic text-white/90 leading-relaxed">
-                    "{t(`testimonials.quote${n}`)}"
-                  </p>
-                </div>
-              </ScrollAnimation>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Divider: Testimonials → Pricing (navy → porcelain) */}
-      <SectionDivider fromColor="#1A2D63" toColor="#FDFBF7" variant={2} />
 
       {/* ───────── 8. PRICING ───────── */}
       <ScrollAnimation>
@@ -336,12 +239,12 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
                       onClick={() => setOpenFaq(openFaq === n ? null : n)}
                       className="w-full flex items-center justify-between px-5 py-4 sm:px-6 sm:py-5 text-left gap-4 hover:bg-navy/[0.015] transition-colors duration-150"
                     >
-                      <span className="font-instrument font-semibold text-[14px] sm:text-[15px] md:text-base text-navy leading-snug">{t(`faq.q${n}`)}</span>
+                      <span className="font-instrument font-semibold text-[15px] sm:text-base text-navy leading-snug">{t(`faq.q${n}`)}</span>
                       <ChevronDown className={`w-4 h-4 sm:w-5 sm:h-5 text-navy/40 flex-shrink-0 transition-transform duration-300 ${openFaq === n ? 'rotate-180' : ''}`} />
                     </button>
                     <div className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${openFaq === n ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
                       <div className="overflow-hidden min-h-0">
-                        <div className="px-5 pb-5 sm:px-6 sm:pb-6 pt-1 font-instrument text-[13px] sm:text-[14px] text-slate-blue leading-relaxed [&_p]:leading-relaxed [&_ul]:space-y-1.5 [&_ol]:space-y-2">
+                        <div className="px-5 pb-5 sm:px-6 sm:pb-6 pt-1 font-instrument text-[14px] sm:text-[15px] text-slate-blue leading-relaxed [&_p]:leading-relaxed [&_ul]:space-y-1.5 [&_ol]:space-y-2">
                           {currentLanguage === 'nl'
                             ? faqContentNl[n - 1]
                             : <p>{t(`faq.a${n}`)}</p>
@@ -369,7 +272,7 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
               <div className="absolute -bottom-20 -left-20 w-60 h-60 bg-glow-blue/15 rounded-full blur-3xl"></div>
 
               <div className="relative z-10">
-                <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold leading-[1.15] text-navy mb-6">
+                <h2 className="font-general text-3xl sm:text-4xl md:text-5xl 2xl:text-6xl font-bold leading-[1.15] text-navy mb-6">
                   {t('finalCta.title')}
                 </h2>
                 <p className="text-base md:text-lg font-instrument font-medium text-slate-blue leading-relaxed mb-10 max-w-2xl mx-auto">
@@ -419,14 +322,15 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
       {/* ───────── 11. FOOTER ───────── */}
       <footer className="text-white bg-navy relative z-10">
         {/* Upper CTA + contact area */}
-        <div className="max-w-7xl mx-auto px-6 pt-8 pb-12">
+        <div className="max-w-7xl mx-auto px-6 pt-3 pb-12">
           <div className="flex flex-col lg:flex-row items-start gap-10 lg:gap-16">
 
             {/* Left: headline + subline + three CTA buttons */}
             <div className="flex-1 flex flex-col gap-6">
               <div>
-                <h2 className="font-general text-3xl sm:text-4xl md:text-5xl font-bold text-white leading-snug mb-4 whitespace-pre-line">
-                  {t('footer.ctaHeadline')}
+                <h2 className="font-general font-bold text-white leading-[1.1] mb-4">
+                  <span className="block text-4xl sm:text-5xl md:text-6xl">{t('footer.ctaHeadline').split('\n')[0]}</span>
+                  <span className="block text-2xl sm:text-3xl md:text-4xl text-white/75 mt-1">{t('footer.ctaHeadline').split('\n')[1]}</span>
                 </h2>
                 <p className="text-white/60 font-instrument text-lg leading-relaxed max-w-lg">
                   {t('footer.ctaSubline')}
@@ -446,12 +350,6 @@ export const Homepage: React.FC<HomepageProps> = ({ openContactModal }) => {
               >
                 <Play className="w-4 h-4" />
                 {t('finalCta.watchDemo')}
-              </button>
-              <button
-                onClick={openContactModal}
-                className="border border-white/25 text-white font-semibold text-sm py-3 px-6 rounded-full hover:bg-white/10 transition-all duration-200 w-fit"
-              >
-                {t('navigation.contact')}
               </button>
               </div>
             </div>

--- a/src/components/HowItWorksDemo.tsx
+++ b/src/components/HowItWorksDemo.tsx
@@ -1,6 +1,28 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useI18n } from '../hooks/useI18n';
-import { useScaleFactor, useIsMobile } from '../hooks/useBreakpoint';
+import { useIsMobile } from '../hooks/useBreakpoint';
+
+// Local scale factor for the demo window. Extends past the shared hook so the
+// window keeps growing (proportions intact via `zoom`) on large viewports,
+// instead of staying narrow. Paired with the wider max-width wrapper below.
+function useDemoScaleFactor() {
+  const getScale = () => {
+    const w = window.innerWidth;
+    if (w >= 2200) return 1.55;
+    if (w >= 1920) return 1.42;
+    if (w >= 1700) return 1.28;
+    if (w >= 1536) return 1.15;
+    if (w >= 1280) return 1.06;
+    return 1;
+  };
+  const [scale, setScale] = useState(getScale);
+  useEffect(() => {
+    const onResize = () => setScale(getScale());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+  return scale;
+}
 
 type Phase = 'idle' | 'voice' | 'transcript' | 'thinking' | 'reply' | 'crm' | 'done';
 
@@ -101,7 +123,9 @@ export const HowItWorksDemo: React.FC = () => {
   const [crmScrolled, setCrmScrolled] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [loopFading, setLoopFading] = useState(false);
+  const [replyHeight, setReplyHeight] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const replyBubbleRef = useRef<HTMLDivElement>(null);
   const timeoutRefs = useRef<number[]>([]);
   const rafRef = useRef<number | null>(null);
   const hasStarted = useRef(false);
@@ -131,6 +155,17 @@ export const HowItWorksDemo: React.FC = () => {
     );
     observer.observe(el);
     return () => observer.disconnect();
+  }, []);
+
+  // Measure the reply bubble's real height so the voice bubble can sit just
+  // above it on any screen width (narrow screens wrap text → taller bubble).
+  useEffect(() => {
+    const el = replyBubbleRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => setReplyHeight(el.offsetHeight));
+    ro.observe(el);
+    setReplyHeight(el.offsetHeight);
+    return () => ro.disconnect();
   }, []);
 
   const startTypewriter = useCallback((onDone: () => void) => {
@@ -228,23 +263,23 @@ export const HowItWorksDemo: React.FC = () => {
 
   const showCrm = phaseGte('crm');
 
-  const scale = useScaleFactor();
+  const scale = useDemoScaleFactor();
   const isMobile = useIsMobile();
 
   return (
-    <div ref={containerRef} className="flex flex-col lg:flex-row gap-8 lg:gap-14 items-start" style={{ minHeight: Math.round(500 * scale) }}>
+    <div ref={containerRef} className="flex flex-col items-center gap-8 lg:gap-12">
 
-      {/* ─── macOS Window + Chat ─── */}
-      <div className="w-full lg:w-[55%] flex-shrink-0">
+      {/* ─── macOS Window + Chat (centered, prominent) ─── */}
+      <div className="w-full max-w-[760px] xl:max-w-[880px] 2xl:max-w-[1040px] mx-auto">
         <div className="relative">
           {/* Backdrop shadow — elevated "floating" effect */}
           <div
             className="absolute pointer-events-none"
             style={{
-              inset: '-24px -20px -36px -20px',
+              inset: '-18px -14px -28px -14px',
               borderRadius: '38px',
               background: 'radial-gradient(ellipse at 50% 45%, rgba(26,45,99,0.18) 0%, rgba(26,45,99,0.06) 55%, transparent 80%)',
-              filter: 'blur(24px)',
+              filter: 'blur(20px)',
             }}
           />
           <div
@@ -315,7 +350,7 @@ export const HowItWorksDemo: React.FC = () => {
                     transform: phase === 'idle'
                       ? `translateY(${isMobile ? 210 : 230}px)`
                       : bubbleShifted
-                        ? `translateY(${isMobile ? -80 : 0}px)`
+                        ? `translateY(${isMobile ? (replyHeight ? 194 - replyHeight : -15) : 0}px)`
                         : phaseGte('thinking')
                           ? `translateY(${isMobile ? 170 : 190}px)`
                           : `translateY(${isMobile ? 210 : 230}px)`,
@@ -455,6 +490,7 @@ export const HowItWorksDemo: React.FC = () => {
 
                 {/* ── Bot reply bubble (received — white) — slides up like the green bubble ── */}
                 <div
+                  ref={replyBubbleRef}
                   className="absolute left-[16px] md:left-[52px] right-[16px] md:right-[52px]"
                   style={{
                     bottom: '10px',
@@ -646,7 +682,7 @@ export const HowItWorksDemo: React.FC = () => {
                     <div
                       className="flex flex-col gap-2"
                       style={{
-                        transform: crmScrolled ? 'translateY(-82px)' : 'translateY(0)',
+                        transform: 'translateY(0)',
                         transition: 'transform 1.1s cubic-bezier(0.22, 1, 0.36, 1)',
                       }}
                     >
@@ -722,7 +758,7 @@ export const HowItWorksDemo: React.FC = () => {
                         className="absolute left-0 right-0 rounded-full"
                         style={{
                           backgroundColor: 'rgba(0,0,0,0.16)',
-                          top: crmScrolled ? '45%' : '4%',
+                          top: '4%',
                           height: '28%',
                           transition: 'top 1.1s cubic-bezier(0.22, 1, 0.36, 1)',
                         }}
@@ -901,9 +937,19 @@ export const HowItWorksDemo: React.FC = () => {
         </div>
       </div>
 
-      {/* ─── Step Timeline (vertically centered) ─── */}
+      {/* ─── Title + subtitle ─── */}
+      <div className="text-center max-w-3xl mx-auto px-4 mt-6 sm:mt-2">
+        <h2 className="font-general text-3xl sm:text-4xl md:text-5xl 2xl:text-6xl font-bold leading-[1.15] text-navy mb-2 md:mb-4">
+          {t('howItWorks.title')}
+        </h2>
+        <p className="text-lg md:text-xl xl:text-2xl font-instrument font-medium text-navy/60 max-w-3xl mx-auto">
+          {t('howItWorks.subtitle')}
+        </p>
+      </div>
+
+      {/* ─── MOBILE: vertical timeline (no cards/borders) ─── */}
       <div
-        className="w-full lg:w-[45%] flex items-center justify-center lg:-mt-2"
+        className="sm:hidden w-full flex justify-center px-4"
         style={{
           opacity: loopFading ? 0 : 1,
           transition: 'opacity 0.6s ease',
@@ -916,7 +962,7 @@ export const HowItWorksDemo: React.FC = () => {
             const isCurrent = activeStep === stepNum;
 
             return (
-              <div key={i} className="flex gap-5 lg:gap-6 items-stretch relative">
+              <div key={i} className="flex gap-5 items-stretch relative">
                 {/* Circle + line */}
                 <div className="flex flex-col items-center flex-shrink-0 relative">
                   <div
@@ -979,14 +1025,112 @@ export const HowItWorksDemo: React.FC = () => {
                 </div>
 
                 {/* Text */}
+                <div className="pt-[10px] pb-3">
+                  <h4
+                    className="font-general font-bold text-[17px] leading-tight mb-1.5"
+                    style={{ color: '#1A2D63', transition: 'color 0.5s' }}
+                  >
+                    {step.title}
+                  </h4>
+                  <p
+                    className="font-instrument text-[14px] leading-relaxed max-w-[500px]"
+                    style={{ color: 'rgba(26, 45, 99, 0.52)', transition: 'color 0.5s' }}
+                  >
+                    {step.description}
+                  </p>
+                  <div
+                    className="mt-3 h-[2.5px] rounded-full overflow-hidden w-28"
+                    style={{
+                      backgroundColor: isCurrent ? 'rgba(26, 45, 99, 0.1)' : 'transparent',
+                      transition: 'background-color 0.3s ease',
+                    }}
+                  >
+                    {isCurrent && (
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          backgroundColor: '#1A2D63',
+                          animation: `progress-bar ${stepNum === 1 ? '4s' : stepNum === 2 ? '2s' : stepNum === 3 ? '2s' : '3.5s'} ease-out forwards`,
+                        }}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ─── DESKTOP: 4 steps — 2x2 grid ─── */}
+      <div
+        className="hidden sm:grid grid-cols-2 gap-4 md:gap-5 w-full max-w-6xl mx-auto"
+        style={{
+          opacity: loopFading ? 0 : 1,
+          transition: 'opacity 0.6s ease',
+        }}
+      >
+        {steps.map((step, i) => {
+            const stepNum = i + 1;
+            const isActive = activeStep >= stepNum;
+            const isCurrent = activeStep === stepNum;
+
+            return (
+              <div
+                key={i}
+                className="flex gap-4 items-start rounded-2xl border p-5 md:p-6 transition-all duration-500"
+                style={{
+                  borderColor: isActive ? 'rgba(26,45,99,0.16)' : 'rgba(26,45,99,0.07)',
+                  background: isCurrent ? 'rgba(26,45,99,0.035)' : 'transparent',
+                  opacity: isMobile || isActive ? 1 : 0.5,
+                }}
+              >
                 <div
-                  className="pt-[10px] pb-3"
-                  style={{
-                    opacity: isMobile || isActive ? 1 : 0.28,
-                    transform: isMobile || isActive ? 'translateX(0)' : 'translateX(3px)',
-                    transition: 'all 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
-                  }}
-                >
+                  className="w-12 h-12 rounded-full flex items-center justify-center relative flex-shrink-0"
+                    style={{
+                      background: isActive ? '#1A2D63' : 'transparent',
+                      border: isActive ? 'none' : '2px solid rgba(26, 45, 99, 0.12)',
+                      boxShadow: isActive ? '0 4px 14px rgba(26, 45, 99, 0.22)' : 'none',
+                      transform: isCurrent ? 'scale(1.12)' : 'scale(1)',
+                      transition: 'all 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
+                    }}
+                  >
+                    {/* Step 1: Microphone */}
+                    {i === 0 && (
+                      <svg className="w-[22px] h-[22px]" viewBox="0 0 24 24" fill="none" stroke={isActive ? 'white' : 'rgba(26,45,99,0.25)'} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ transition: 'stroke 0.5s' }}>
+                        <path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/>
+                        <path d="M19 10v2a7 7 0 01-14 0v-2"/>
+                        <line x1="12" y1="19" x2="12" y2="23"/>
+                        <line x1="8" y1="23" x2="16" y2="23"/>
+                      </svg>
+                    )}
+                    {/* Step 2: AI Sparkle */}
+                    {i === 1 && (
+                      <svg className="w-[22px] h-[22px]" viewBox="0 0 24 24" fill="none" stroke={isActive ? 'white' : 'rgba(26,45,99,0.25)'} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" style={{ transition: 'stroke 0.5s' }}>
+                        <path d="M12 3v3M12 18v3M3 12h3M18 12h3"/>
+                        <path d="M12 3c0 4.97 4.03 9 9 9-4.97 0-9 4.03-9 9 0-4.97-4.03-9-9-9 4.97 0 9-4.03 9-9z"/>
+                        <path d="M19 3c0 1.1.9 2 2 2-1.1 0-2 .9-2 2 0-1.1-.9-2-2-2 1.1 0 2-.9 2-2z" strokeWidth="1.4"/>
+                      </svg>
+                    )}
+                    {/* Step 3: Confirmation checkmark */}
+                    {i === 2 && (
+                      <svg className="w-[22px] h-[22px]" viewBox="0 0 24 24" fill="none" stroke={isActive ? 'white' : 'rgba(26,45,99,0.25)'} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ transition: 'stroke 0.5s' }}>
+                        <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/>
+                        <polyline points="22 4 12 14.01 9 11.01"/>
+                      </svg>
+                    )}
+                    {/* Step 4: Database */}
+                    {i === 3 && (
+                      <svg className="w-[22px] h-[22px]" viewBox="0 0 24 24" fill="none" stroke={isActive ? 'white' : 'rgba(26,45,99,0.25)'} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ transition: 'stroke 0.5s' }}>
+                        <ellipse cx="12" cy="5" rx="9" ry="3"/>
+                        <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/>
+                        <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
+                      </svg>
+                    )}
+                </div>
+
+                {/* Text */}
+                <div className="min-w-0">
                   <h4
                     className="font-general font-bold text-[17px] lg:text-[18px] xl:text-[20px] 2xl:text-[22px] leading-tight mb-1.5"
                     style={{
@@ -1026,7 +1170,6 @@ export const HowItWorksDemo: React.FC = () => {
               </div>
             );
           })}
-        </div>
       </div>
     </div>
   );

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,5 +1,19 @@
 import React, { useCallback, useRef } from 'react';
-import { Check, ArrowRight, ChevronLeft, ChevronRight, Minus, Plus } from 'lucide-react';
+import {
+  Check,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  Minus,
+  Plus,
+  MessageSquare,
+  Users,
+  StickyNote,
+  CheckSquare,
+  Calendar,
+  FileText,
+  MoreHorizontal,
+} from 'lucide-react';
 import { BillingPeriodSwitch, BillingPeriod } from './BillingPeriodSwitch';
 import { useI18n } from '../hooks/useI18n';
 import { withUTM } from '../utils/utm';
@@ -141,9 +155,52 @@ function formatPrice(price: number): string {
   return price % 1 === 0 ? String(price) : price.toFixed(2);
 }
 
+// Format a euro amount with NL-style decimals (€57,60). Used for the yearly
+// savings badge so it reads naturally for the Belgian/NL audience.
+function formatEuro(amount: number): string {
+  return '€' + amount.toFixed(2).replace('.', ',');
+}
+
+// Small inline language map for the "/ per user" suffix on the yearly savings
+// badge. Kept inline on purpose so we don't touch the shared locale JSON
+// (another session may be editing it).
+const PER_USER_SUFFIX: Record<string, string> = {
+  en: '/user',
+  nl: '/gebruiker',
+  fr: '/utilisateur',
+  de: '/Nutzer',
+};
+
+// Title above the +/- user counter. Inline map (don't touch shared locale JSON).
+const USERS_LABEL: Record<string, string> = {
+  en: 'Users',
+  nl: 'Gebruikers',
+  fr: 'Utilisateurs',
+  de: 'Nutzer',
+};
+
+// Icons for the "Use your credits for" list, in the same order as the
+// pricing.creditUses i18n array.
+const CREDIT_USE_ICONS = [
+  MessageSquare, // ± messages per month
+  Users,         // Contacts
+  StickyNote,    // Notes
+  CheckSquare,   // Tasks
+  Calendar,      // Appointments
+  FileText,      // Quotes & invoices
+  MoreHorizontal, // More
+];
+
+// Pull the upper bound from a "20–30" / "200–285" style range so the first
+// credit-use line can show a concrete estimate per plan.
+function approxUpperBound(creditsApprox: string): string {
+  const parts = creditsApprox.split(/[–-]/);
+  return (parts[parts.length - 1] ?? creditsApprox).trim();
+}
+
 
 export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal }) => {
-  const { t } = useI18n();
+  const { t, currentLanguage } = useI18n();
   const { navigateWithTransition } = usePageTransition();
   const [billingPeriod, setBillingPeriod] = React.useState<BillingPeriod>('monthly');
   const [currentCardIdx, setCurrentCardIdx] = React.useState(0);
@@ -232,12 +289,15 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
     const count = userCounts[plan.key] ?? 1;
     const displayValue = inputValues[plan.key] ?? String(count);
     return (
-      <div className="mb-4">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col items-start gap-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-blue/70 leading-none">
+          {USERS_LABEL[currentLanguage] ?? USERS_LABEL.en}
+        </span>
+        <div className="flex items-center gap-1.5">
           <button
             onClick={() => updateUserCount(plan.key, count - 1)}
             disabled={count <= 1}
-            className="w-8 h-8 rounded-full border border-navy/20 bg-white flex items-center justify-center text-navy hover:bg-navy/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
+            className="w-7 h-7 rounded-full border border-navy/20 bg-white flex items-center justify-center text-navy hover:bg-navy/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
             aria-label="Decrease users"
           >
             <Minus size={13} />
@@ -262,17 +322,16 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
               setUserCounts(prev => ({ ...prev, [plan.key]: clamped }));
               setInputValues(prev => ({ ...prev, [plan.key]: String(clamped) }));
             }}
-            className="w-14 text-center text-sm font-semibold text-navy border border-navy/20 rounded-lg py-1 focus:outline-none focus:ring-2 focus:ring-navy/20"
+            className="w-10 text-center text-sm font-semibold text-navy border border-navy/20 rounded-lg py-0.5 focus:outline-none focus:ring-2 focus:ring-navy/20"
           />
           <button
             onClick={() => updateUserCount(plan.key, count + 1)}
             disabled={count >= 50}
-            className="w-8 h-8 rounded-full border border-navy/20 bg-white flex items-center justify-center text-navy hover:bg-navy/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
+            className="w-7 h-7 rounded-full border border-navy/20 bg-white flex items-center justify-center text-navy hover:bg-navy/5 transition-colors disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
             aria-label="Increase users"
           >
             <Plus size={13} />
           </button>
-          <span className="text-xs text-slate-blue font-instrument">{t('pricing.users')}</span>
         </div>
       </div>
     );
@@ -285,10 +344,37 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
       ? 0
       : Math.round((1 - pricePerUser / plan.baseMonthlyPrice) * 100);
     const showStrikethrough = totalDiscountPct > 0;
+    // Yearly savings per user: the monthly per-user price (before the yearly
+    // discount) × 12 × 20%. Shown in the green badge when yearly is selected.
+    const monthlyPerUser = getPricePerUser(plan, users, 'monthly');
+    const yearlySavingsPerUser = monthlyPerUser * 12 * 0.2;
 
-    const padding = desktop ? 'p-6 lg:p-8 2xl:p-10' : 'p-6';
-    const titleSize = desktop ? 'text-xl 2xl:text-2xl' : 'text-xl';
+    const padding = desktop ? 'p-6 lg:p-7 2xl:p-8' : 'p-6';
+    const titleSize = desktop ? 'text-3xl 2xl:text-4xl' : 'text-3xl';
     const priceSize = desktop ? 'text-4xl 2xl:text-5xl' : 'text-4xl';
+
+    // "Use your credits for" — shared list of what credits buy. The first line
+    // is rebuilt to show this plan's concrete estimated message count.
+    const creditUsesRaw = t('pricing.creditUses', { returnObjects: true });
+    const creditUses = Array.isArray(creditUsesRaw) ? (creditUsesRaw as string[]) : [];
+    const creditUsesTitle = t('pricing.creditUsesTitle');
+
+    // Support / feature ladder for this specific plan. features[0] is a heading
+    // ("Everything from X, plus:" / "Included:"), the rest are bullets.
+    const planFeaturesRaw = t(`pricing.cards.${plan.key}.features`, { returnObjects: true });
+    const planFeatures = Array.isArray(planFeaturesRaw) ? (planFeaturesRaw as string[]) : [];
+    // Free Trial has no "Everything from X" ladder — give it the neutral
+    // "Included:" heading so its block lines up with the other cards.
+    const featuresHeading = plan.isFreeTrial
+      ? t('pricing.includedHeading')
+      : (planFeatures[0] ?? '');
+    const featureBullets = plan.isFreeTrial ? planFeatures : planFeatures.slice(1);
+
+    // Shared section heading style — identical for "Use your credits for:" and
+    // "Everything from X, plus:" so they read as one consistent system and
+    // align across cards.
+    const sectionHeadingClass =
+      'text-[13px] font-bold uppercase tracking-wide text-navy mb-2.5';
 
     return (
       <div
@@ -300,94 +386,74 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
             : 'shadow-md border border-navy/[0.06] hover:shadow-lg hover:scale-[1.01]'
         }`}
       >
-        {/* Header */}
-        <div className="mb-5">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className={`${titleSize} font-bold text-navy`}>
-              {t(`pricing.cards.${plan.key}.name`)}
-            </h3>
-            {plan.highlighted && (
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-navy text-white whitespace-nowrap flex-shrink-0">
-                {t('pricing.cards.professional.badge')}
-              </span>
-            )}
-          </div>
-          <p className="text-sm text-slate-blue font-instrument mt-1">
-            {t(`pricing.cards.${plan.key}.description`)}
-          </p>
+        {/* "Most popular" badge — sits on the top-right card edge, vertically
+            centered on the border so its top half rises above the frame and its
+            bottom half stays inside. */}
+        {plan.highlighted && (
+          <span className="absolute top-0 right-6 -translate-y-1/2 inline-flex items-center px-4 py-1.5 rounded-full text-sm font-semibold bg-navy text-white whitespace-nowrap shadow-md z-10">
+            {t('pricing.cards.professional.badge')}
+          </span>
+        )}
+
+        {/* Header — fixed height so the price row starts at the same Y on every card */}
+        <div className="min-h-[40px] mb-2">
+          <h3 className={`${titleSize} font-bold text-navy leading-tight`}>
+            {t(`pricing.cards.${plan.key}.name`)}
+          </h3>
         </div>
 
-        {/* Price */}
-        <div className="mb-4">
+        {/* Price — big amount left, small 2-line "user / month" label beside it,
+            and (paid multi-seat plans) the +/- user selector right of that.
+            At yearly the strikethrough widens the row, so the selector wraps to
+            a second line; the min-height grows by billing period so every card's
+            CTA drops by the same amount and stays aligned. */}
+        <div className="min-h-[56px]">
           {plan.isFreeTrial ? (
-            <>
-              <span className={`${priceSize} font-bold text-navy`}>€0</span>
-              <p className="text-xs text-slate-blue font-instrument mt-1">
+            <div className="flex items-end gap-2">
+              <span className={`${priceSize} font-bold text-navy leading-none`}>€0</span>
+              <span className="text-[13px] leading-tight text-slate-blue font-instrument pb-1">
                 {t('pricing.cards.freetrial.billingNote')}
-              </p>
-            </>
+              </span>
+            </div>
           ) : (
-            <div>
-              <div className="flex items-baseline gap-x-2 gap-y-0.5 flex-wrap">
-                {showStrikethrough && (
-                  <span className="text-xl font-bold text-navy/30 line-through">
-                    €{formatPrice(plan.baseMonthlyPrice)}
-                  </span>
-                )}
-                <span className={`${priceSize} font-bold text-navy`}>
-                  €{formatPrice(pricePerUser)}
+            <div className="flex items-end flex-wrap gap-x-2 gap-y-2">
+              {showStrikethrough && (
+                <span className="text-xl font-bold text-navy/30 line-through pb-1">
+                  €{formatPrice(plan.baseMonthlyPrice)}
                 </span>
-                {totalDiscountPct > 0 && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-green-50 border border-green-200 text-green-700">
-                    -{totalDiscountPct}%
-                  </span>
-                )}
-              </div>
-              <p className="text-slate-blue text-sm mt-0.5">{t('pricing.perUserPerMonth')}</p>
+              )}
+              <span className={`${priceSize} font-bold text-navy leading-none`}>
+                €{formatPrice(pricePerUser)}
+              </span>
+              <span className="text-[13px] leading-tight text-slate-blue font-instrument pb-1">
+                {t('pricing.perUserLine1')}
+                <br />
+                {t('pricing.perUserLine2')}
+              </span>
             </div>
           )}
         </div>
 
-        {/* User count control (Professional & Business only) */}
-        {renderUserControl(plan)}
-
-        {/* Credits box */}
-        <div className="mb-4 px-3 py-2.5 bg-blue-50/80 rounded-xl">
-          <p className="text-sm font-semibold text-navy">
-            {plan.isFreeTrial
-              ? t('pricing.oneTimeCredits', { count: plan.credits })
-              : t('pricing.creditsPerUserPerMonth', { count: plan.credits })}
-          </p>
-          <p className="text-xs text-slate-blue font-instrument mt-0.5">
-            ≈ {plan.creditsApprox} {t('pricing.voiceMessages')}
-          </p>
+        {/* User counter — below the price; reserved height on every card so all
+            CTAs stay aligned whether or not the card shows the selector. */}
+        <div className="min-h-[48px]">
+          {renderUserControl(plan)}
         </div>
 
-        {/* Features */}
-        <div className="space-y-2.5 mb-5 flex-grow">
-          {plan.featureKeys.map((featureKey, index) => (
-            <div key={index} className="flex items-center space-x-3">
-              <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${
-                plan.highlighted ? 'bg-navy' : 'bg-navy/10'
-              }`}>
-                <Check className={`w-3 h-3 ${plan.highlighted ? 'text-white' : 'text-navy'}`} />
-              </div>
-              <span className="text-sm 2xl:text-base text-slate-blue font-instrument">{t(featureKey)}</span>
-            </div>
-          ))}
+        {/* Special offer — reserve height only at yearly (where the badge shows);
+            on monthly it collapses so the CTA sits closer to the price. */}
+        <div className={billingPeriod === 'yearly' ? 'min-h-[28px] mt-2' : 'mt-1'}>
+          {!plan.isFreeTrial && billingPeriod === 'yearly' && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-green-50 border border-green-200 text-green-700">
+              {t('pricing.save20')} - {formatEuro(yearlySavingsPerUser)} {PER_USER_SUFFIX[currentLanguage] ?? PER_USER_SUFFIX.en}
+            </span>
+          )}
         </div>
 
-        {/* Auto top-up info (Professional & Business) */}
-        {plan.hasAutoTopUp && (
-          <div className="mb-4 px-3 py-2 bg-glow-blue/10 border border-glow-blue/20 rounded-xl">
-            <p className="text-xs font-medium text-navy/80">{t('pricing.autoTopUpInfo')}</p>
-          </div>
-        )}
-
-        {/* CTA */}
+        {/* CTA — sits high in the card, same Y across all cards */}
         <button
           onClick={() => handleCtaClick(plan)}
-          className={`w-full font-semibold py-3 px-6 rounded-full transition-all duration-300 hover:shadow-lg flex items-center justify-center gap-2 group ${
+          className={`w-full font-semibold py-3 px-6 rounded-full transition-all duration-300 hover:shadow-lg flex items-center justify-center gap-2 group mt-2 ${
             plan.highlighted
               ? 'bg-navy text-white hover:bg-navy-hover hover:shadow-xl'
               : 'border-2 border-navy text-navy hover:bg-navy hover:text-white'
@@ -399,11 +465,82 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
           )}
         </button>
 
-        {/* Subtext */}
-        {(plan.isFreeTrial || plan.key === 'starter') && (
-          <p className="text-center text-xs text-muted-blue mt-3">
-            {t(`pricing.cards.${plan.key}.subtext`)}
+        {/* Divider under the CTA — Monday-style separation */}
+        <div className="border-t border-navy/10 my-5" />
+
+        {/* Credits — same vertical height across cards */}
+        <div className="min-h-[28px]">
+          <p className="text-[15px] font-semibold text-navy">
+            {plan.isFreeTrial
+              ? t('pricing.oneTimeCredits', { count: plan.credits })
+              : t('pricing.creditsPerUserPerMonth', { count: plan.credits })}
           </p>
+        </div>
+
+        {/* Use your credits for — dark navy heading + darker icons */}
+        {creditUses.length > 0 && (
+          <div className="mt-4">
+            <p className={sectionHeadingClass}>{creditUsesTitle}</p>
+            <ul className="space-y-2">
+              {creditUses.map((label, index) => {
+                const Icon = CREDIT_USE_ICONS[index] ?? MoreHorizontal;
+                // First line is the "± N messages per month" estimate. Bold just
+                // the number so it stands out; the rest of the line stays normal.
+                let content: React.ReactNode = label;
+                if (index === 0) {
+                  const num = approxUpperBound(plan.creditsApprox);
+                  const [before, after] = label.split('±');
+                  // Free trial isn't a monthly subscription, so drop the
+                  // "per month" suffix there (kept on paid tiers).
+                  const MONTHLY_SUFFIX: Record<string, string> = {
+                    nl: 'per maand', en: 'per month', fr: 'par mois', de: 'pro Monat',
+                  };
+                  const suffix = MONTHLY_SUFFIX[currentLanguage] ?? MONTHLY_SUFFIX.en;
+                  const afterText = plan.isFreeTrial
+                    ? after.replace(suffix, '').trimEnd()
+                    : after;
+                  content = (
+                    <>
+                      {before}± <span className="font-semibold text-navy">{num}</span>
+                      {afterText}
+                    </>
+                  );
+                }
+                return (
+                  <li key={index} className="flex items-center gap-2.5">
+                    <Icon className="w-4 h-4 text-navy/70 flex-shrink-0" strokeWidth={2.25} />
+                    <span className="text-[15px] text-slate-blue font-instrument">{content}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {/* "Everything from X, plus:" heading + feature bullets */}
+        {(featuresHeading || featureBullets.length > 0) && (
+          <div className="mt-5">
+            {featuresHeading && <p className={sectionHeadingClass}>{featuresHeading}</p>}
+            <div className="space-y-2.5">
+              {featureBullets.map((feature, index) => (
+                <div key={index} className="flex items-center gap-3">
+                  <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${
+                    plan.highlighted ? 'bg-navy' : 'bg-navy/10'
+                  }`}>
+                    <Check className={`w-3 h-3 ${plan.highlighted ? 'text-white' : 'text-navy'}`} />
+                  </div>
+                  <span className="text-[15px] text-slate-blue font-instrument">{feature}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Auto top-up info (Professional & Business) */}
+        {plan.hasAutoTopUp && (
+          <div className="mt-4 px-3 py-2 bg-glow-blue/10 border border-glow-blue/20 rounded-xl">
+            <p className="text-xs font-medium text-navy/80">{t('pricing.autoTopUpInfo')}</p>
+          </div>
         )}
       </div>
     );
@@ -446,7 +583,7 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
   return (
     <div className="max-w-[1400px] 2xl:max-w-screen-2xl mx-auto px-6">
       <div className="text-center mb-8 2xl:mb-10">
-        <h2 className="font-general text-4xl lg:text-5xl 2xl:text-6xl font-bold text-navy mb-4">
+        <h2 className="font-general text-3xl sm:text-4xl md:text-5xl 2xl:text-6xl font-bold text-navy mb-4">
           {t('pricing.title')}
         </h2>
         <p className="text-xl 2xl:text-2xl font-instrument text-slate-blue max-w-3xl mx-auto mb-6">
@@ -485,11 +622,11 @@ export const PricingSection: React.FC<PricingSectionProps> = ({ openContactModal
       {/* Mobile: snap scroll carousel */}
       <div
         ref={mobileScrollRef}
-        className="md:hidden overflow-x-auto snap-x snap-mandatory flex gap-4 -mx-6 px-5 pb-4"
+        className="md:hidden overflow-x-auto snap-x snap-mandatory flex gap-4 -mx-6 px-5 -my-6 py-6"
         style={{ scrollbarWidth: 'none', WebkitOverflowScrolling: 'touch' } as React.CSSProperties}
       >
         {plans.map((plan) => (
-          <div key={plan.key} className="snap-center flex-shrink-0 w-[calc(100svw-2.5rem)]">
+          <div key={plan.key} className="snap-center flex-shrink-0 w-[85vw]">
             {renderCardContent(plan, false)}
           </div>
         ))}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -207,8 +207,8 @@
     "submitFailed": "Nachricht senden fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktieren Sie uns direkt."
   },
   "footer": {
-    "ctaHeadline": "Sprechen Sie. Wir kümmern uns um den Rest.",
-    "ctaSubline": "Eine Sprachnachricht auf WhatsApp genügt, um Ihr CRM aktuell zu halten.",
+    "ctaHeadline": "Just… talk.\nDein CRM bleibt aktuell.",
+    "ctaSubline": "Füge Informationen hinzu, rufe Kundendaten ab und verwalte dein CRM direkt über WhatsApp.",
     "copyright": "© 2025 Finit Solutions",
     "privacy": "Datenschutz",
     "saasAgreement": "SaaS-Vereinbarung",
@@ -322,7 +322,7 @@
     "integrations": "Was es kann",
     "contact": "Kontakt",
     "maatwerkAI": "Individuelle KI",
-    "affiliate": "Partnerprogramm",
+    "affiliate": "Partner werden",
     "urgentQuestions": "Lieber direkt Kontakt?",
     "callUs": "Rufen Sie uns an",
     "callHours": "Mo-Sa · 8:30-19:00"
@@ -330,17 +330,23 @@
   "hero": {
     "title": "Einfach...",
     "mainTitle": "Sprechen Sie mit Ihrem CRM",
-    "subtitle1_pre": "Connect your",
+    "subtitle1_pre": "VoiceLink verbindet",
     "subtitle1_crm": "Teamleader CRM",
-    "subtitle1_mid": "with",
+    "subtitle1_mid": "mit",
     "subtitle1_wa": "WhatsApp",
-    "subtitle1_post": "and handle all your admin with a simple voice message.",
+    "subtitle1_post": ", sodass du mit einer einzigen Sprachnachricht Kundennotizen hinzufügst, Follow-ups erfasst, Aufgaben erstellst und CRM-Informationen abrufst. Ohne Teamleader zu öffnen.",
     "subtitle2": "Verwandeln Sie Sprachnachrichten sofort in strukturierte Daten.",
-    "getStartedFree": "Kostenlos Starten",
-    "watchDemo": "Demo Ansehen",
+    "getStartedFree": "Kostenlos starten",
+    "watchDemo": "Demo ansehen",
+    "howToInstall": "Wie einrichten?",
     "oneClickSetup": "Ein-Klick CRM Verbindung",
     "whatsappSetup": "WhatsApp verbinden\nin 2 Minuten",
-    "carouselTitle": "See what VoiceLink does inside your CRM"
+    "carouselTitle": "Was kann VoiceLink in deinem CRM?",
+    "staticTitle": "Verwalte dein CRM über WhatsApp",
+    "subtitleFull": "VoiceLink verbindet Teamleader mit WhatsApp, sodass du mit einer einzigen Sprachnachricht Kundennotizen hinzufügst, Follow-ups erfasst, Aufgaben erstellst und CRM-Informationen abrufst. Ohne Teamleader zu öffnen.",
+    "bulletSetup": "In wenigen Minuten eingerichtet",
+    "bulletNoTech": "Keine technischen Kenntnisse nötig",
+    "bulletNoCard": "Keine Kreditkarte erforderlich"
   },
   "dashboard": {
     "welcome": "Willkommen zurück, {{name}}!",
@@ -571,22 +577,22 @@
   },
   "howItWorks": {
     "title": "Wie funktioniert es?",
-    "subtitle": "In vier Schritten von der Sprachnachricht in Ihr CRM",
+    "subtitle": "In vier Schritten von der Sprache in Ihr CRM",
     "step1": {
-      "title": "Nachricht senden",
-      "description": "Öffnen Sie WhatsApp und senden Sie eine Sprachnachricht oder Text — ganz wie gewohnt. Fügen Sie neue Infos zu Ihrem CRM hinzu oder suchen Sie bestehende Kontakte und Deals."
+      "title": "Sende eine Nachricht",
+      "description": "Öffne WhatsApp und sende eine Sprachnachricht oder einen Text, so wie du es gewohnt bist. Füge Informationen zu deinem CRM hinzu oder rufe bestehende Kontakte, Deals, Aufgaben und Termine ab."
     },
     "step2": {
-      "title": "VoiceLink erkennt die Infos",
-      "description": "VoiceLink erkennt die wichtigsten Infos — Namen, Nummern, Termine, Notizen — und überlegt, was damit passieren soll."
+      "title": "Die richtigen Informationen werden verarbeitet",
+      "description": "Kontakte, Notizen, Follow-ups, Termine und Verkaufschancen werden automatisch erkannt und dem richtigen Kunden oder Deal zugeordnet."
     },
     "step3": {
-      "title": "Sie bekommen eine Zusammenfassung",
-      "description": "Sofort eine Übersicht zurück in WhatsApp. VoiceLink denkt auch voraus: es kann Fragen stellen oder Vorschläge machen."
+      "title": "Du erhältst sofort Feedback",
+      "description": "Du siehst, welche Informationen gefunden wurden und welche Aktionen ausgeführt werden. Fehlt etwas? Dann erhältst du sofort eine Rückfrage oder einen Vorschlag."
     },
     "step4": {
-      "title": "Alles steht in Ihrem CRM",
-      "description": "Kontakte, Notizen und Aufgaben erscheinen automatisch in Ihrem CRM. Fertig."
+      "title": "Alles landet, wo es hingehört",
+      "description": "Neue Informationen werden zu deinem CRM hinzugefügt und angeforderte Informationen erscheinen direkt zurück in WhatsApp."
     },
     "coreFunctionalities": {
       "title": "Kernfunktionalitäten",
@@ -614,8 +620,8 @@
     }
   },
   "pricing": {
-    "title": "Einfache, Transparente Preise",
-    "subtitle": "Pro-Benutzer-Preise mit klaren Nachrichtenlimits. Starten Sie kostenlos, skalieren Sie mit Ihrem Wachstum.",
+    "title": "Weniger Administration. Mehr Zeit für Kunden.",
+    "subtitle": "Starte kostenlos und verwalte dein CRM direkt über WhatsApp.",
     "monthly": "Monatlich",
     "yearly": "Jährlich",
     "save20": "20% Sparen",
@@ -642,7 +648,7 @@
     "startFreeTrial": "Kostenlose Testversion Starten",
     "freeTrial": "14-tägige kostenlose Testversion",
     "custom": "Individuell",
-    "getCustomQuote": "Angebot Anfordern",
+    "getCustomQuote": "Kontakt aufnehmen",
     "allPlansInclude": "Alle Pläne beinhalten Echtzeit-CRM-Synchronisation, WhatsApp-Integration und mehrsprachige Unterstützung.",
     "free": "Kostenlos",
     "users": "Benutzer",
@@ -652,44 +658,77 @@
     "autoTopUpInfo": "Auto-Aufladung — €7 pro 100 Credits",
     "cards": {
       "freetrial": {
-        "name": "Kostenlose Testversion",
+        "name": "Kostenlos",
         "description": "Testen Sie vor dem Kauf",
-        "cta": "Kostenlos Starten",
+        "cta": "Jetzt kostenlos testen",
         "subtext": "100 kostenlose Credits — keine Karte nötig",
-        "billingNote": "Einmalige Credits, keine Karte nötig"
+        "billingNote": "Einmalige Credits, keine Karte nötig",
+        "features": [
+          "E-Mail-Support"
+        ]
       },
       "starter": {
         "name": "Starter",
         "description": "Für gelegentliche Nutzung",
-        "cta": "Mit Starter Beginnen",
-        "subtext": "E-Mail-Support inklusive"
+        "cta": "Jetzt kostenlos testen",
+        "subtext": "E-Mail-Support inklusive",
+        "features": [
+          "Alles aus der Testphase, plus:",
+          "1-zu-1-Support-Gespräche"
+        ]
       },
       "professional": {
         "name": "Professional",
         "description": "Für tägliche Nutzung",
         "badge": "Am Beliebtesten",
-        "cta": "Zu Professional Wechseln"
+        "cta": "Jetzt kostenlos testen",
+        "features": [
+          "Alles aus Starter, plus:",
+          "Persönlicher Account-Manager",
+          "Mehrere Teammitglieder hinzufügen"
+        ]
       },
       "business": {
         "name": "Business",
         "description": "Für intensive Nutzung",
-        "cta": "Zu Business Wechseln"
+        "cta": "Jetzt kostenlos testen",
+        "features": [
+          "Alles aus Professional, plus:",
+          "Maßgeschneiderte Funktionen auf Anfrage"
+        ]
       },
       "enterprise": {
         "name": "Enterprise",
         "description": "Für Organisationen (25+ Benutzer)",
-        "contactForPricing": "Auf Ihre Bedürfnisse zugeschnitten"
+        "contactForPricing": "Auf Ihre Bedürfnisse zugeschnitten",
+        "features": [
+          "Vollständig auf deine Unternehmensstruktur abgestimmt"
+        ]
       }
-    }
+    },
+    "creditUses": [
+      "± Nachrichten pro Monat",
+      "Kontakte",
+      "Notizen",
+      "Aufgaben",
+      "Termine",
+      "Angebote & Rechnungen",
+      "Mehr"
+    ],
+    "perUserLine1": "Benutzer /",
+    "perUserLine2": "Monat",
+    "totalBilledAnnually": "Insgesamt €{{total}} /Monat, jährlich abgerechnet",
+    "creditUsesTitle": "Nutze deine Credits für:",
+    "includedHeading": "Enthalten:"
   },
   "finalCta": {
-    "title": "Sprechen Sie. Ihr CRM erledigt den Rest.",
-    "subtitle": "Verbinden Sie WhatsApp, senden Sie eine Sprachnachricht – VoiceLink schreibt Kontakte, Notizen und Aufgaben direkt in Ihr CRM.",
-    "startFreeTrial": "Kostenlose Testversion Starten",
-    "watchDemo": "Demo Ansehen",
+    "title": "Bereit, VoiceLink kostenlos auszuprobieren?",
+    "subtitle": "Verbinde dein CRM mit WhatsApp und füge Notizen hinzu, erfasse Follow-ups und rufe Kundeninformationen in einem einzigen Gespräch ab.",
+    "startFreeTrial": "Kostenlos starten",
+    "watchDemo": "Demo ansehen",
     "freeTrialFeatures": {
-      "freeTrialDays": "14-tägige kostenlose Testversion",
-      "noSetupFees": "Keine Einrichtungsgebühren",
+      "freeTrialDays": "100 Gratis-Credits",
+      "noSetupFees": "Keine Kreditkarte erforderlich",
       "cancelAnytime": "Jederzeit kündbar"
     }
   },
@@ -750,12 +789,12 @@
     "title": "Integriert sich mit Ihren Tools"
   },
   "problemAgitation": {
-    "title": "Kommt Ihnen bekannt vor?",
-    "subtitle": "Vertriebsteams verlieren jede Woche Stunden mit manueller CRM-Arbeit.",
-    "pain1": "Sie vergessen Anrufe im CRM zu erfassen, weil Sie bereits beim nächsten sind.",
-    "pain2": "Notizen aus Kundengesprächen stecken in Ihrem Kopf — oder auf einer Serviette.",
-    "pain3": "Ihre Pipeline sieht veraltet aus, weil das Aktualisieren zu lange dauert.",
-    "pain4": "Follow-ups rutschen durch und Deals werden kalt."
+    "title": "Kommt dir bekannt vor?",
+    "subtitle": "Dein CRM hinkt oft dem hinterher, was in deinem Unternehmen wirklich passiert.",
+    "pain1": "Du vergisst, Gespräche zu erfassen, weil du schon beim nächsten Kunden bist.",
+    "pain2": "Wichtige Informationen bleiben in WhatsApp, in Notizen oder in deinem Kopf hängen.",
+    "pain3": "Follow-ups rutschen durch, weil sich die Administration stapelt.",
+    "pain4": "Das Aktualisieren deines CRM fühlt sich an wie zusätzliche Arbeit zu deiner eigentlichen Arbeit."
   },
   "features": {
     "dontSeeYourCrm": "Sie nutzen ein anderes CRM oder eine andere Software? Wir entwickeln maßgeschneiderte Lösungen für jede Plattform, die Sie täglich nutzen.",
@@ -1589,48 +1628,39 @@
   },
   "affiliate": {
     "hero": {
-      "title": "Generieren Sie wiederkehrende Einnahmen, indem Sie VoiceLink Ihrem Netzwerk vorstellen",
-      "subtitle": "Werden Sie VoiceLink-Partner und verdienen Sie 20% wiederkehrende Provisionen bei jedem vermittelten Kunden. Langes Attributionsfenster, monatliche Auszahlungen, alles bereitgestellt.",
-      "stat1": "wiederkehrende Provision",
-      "stat2": "Attributionsfenster",
-      "stat3": "Einnahmen nach Kündigung",
-      "days": "Tage",
-      "months": "Monate",
+      "title": "Werden Sie VoiceLink-Partner",
+      "subtitle": "Stellen Sie VoiceLink Unternehmen in Ihrem Netzwerk vor und erhalten Sie 20% wiederkehrende Provision, solange sie Kunde bleiben. Wir kümmern uns um Demo, Onboarding und Support.",
       "cta1": "Partner werden",
-      "cta2": "Anruf buchen"
+      "cta2": "Kennenlernen planen"
     },
     "howItWorks": {
       "title": "So funktioniert's",
       "step1": {
-        "title": "Registrieren Sie einen Lead",
-        "description": "Senden Sie eine E-Mail an voicelink@finitsolutions.be mit Name, Unternehmen und Kontext."
+        "title": "Lead registrieren",
+        "description": "Senden Sie eine E-Mail an voicelink@finitsolutions.be mit dem Firmennamen, einer Kontaktperson und etwas Kontext."
       },
       "step2": {
-        "title": "Kunde unterzeichnet innerhalb von 90 Tagen",
-        "description": "Wenn Ihr Lead innerhalb von 90 Tagen ein Abonnement abschließt, verdienen Sie Provision."
+        "title": "Kunde wird aktiv",
+        "description": "Wird Ihr Lead innerhalb von 90 Tagen Kunde, wird er Ihnen zugewiesen."
       },
       "step3": {
-        "title": "Erhalten Sie 20% wiederkehrend",
-        "description": "Solange Ihr Kunde bezahlt, erhalten Sie 20% des monatlichen Abonnementwerts."
-      },
-      "step4": {
-        "title": "Quartalsweise Auszahlung",
-        "description": "Monatlich bei 5+ aktiven Kunden, sonst quartalsweise nach Rechnung."
+        "title": "Wiederkehrende Provision erhalten",
+        "description": "Sie erhalten 20% Provision, solange der Kunde aktiv bleibt. Die Auszahlung erfolgt quartalsweise. Ab 5 aktiven Kunden wechseln wir zu monatlicher Auszahlung."
       }
     },
     "whyPartner": {
-      "title": "Warum Partner werden?",
+      "title": "Warum Partner VoiceLink empfehlen",
       "point1": {
-        "title": "Wiederkehrend, nicht einmalig",
-        "description": "Bauen Sie ein Portfolio auf, nicht einmalige Provisionen. Langfristige Beziehung zu Ihren Kunden."
+        "title": "Wir machen die Arbeit",
+        "description": "Demos, Onboarding, Support und Nachverfolgung übernehmen wir. Sie machen die Vorstellung, wir den Rest."
       },
       "point2": {
-        "title": "Großzügiges Attributionsfenster",
-        "description": "90 Tage, um einen Kunden einzuführen. Wiederkehrende Provision, solange der Kunde aktiv und zahlend bleibt."
+        "title": "Passt zu fast jedem Unternehmen",
+        "description": "Fast jedes Unternehmen arbeitet heute mit einem CRM und verliert Zeit durch Verwaltung, Nachverfolgung oder verstreute Kundeninformationen."
       },
       "point3": {
-        "title": "Alles bereitgestellt",
-        "description": "Pitch Deck, Demo-Videos, One-Pager, FAQ. Sie stellen vor, wir kümmern uns um den Rest."
+        "title": "Der Mehrwert ist leicht zu zeigen",
+        "description": "Der Mehrwert ist sofort klar: Kunden verwalten ihr CRM über WhatsApp, ohne ihre bestehende Arbeitsweise zu ändern."
       }
     },
     "accordion": {
@@ -1681,11 +1711,13 @@
         "error": "Etwas ist schief gelaufen. Senden Sie uns eine E-Mail an voicelink@finitsolutions.be."
       },
       "calendly": {
-        "title": "Oder buchen Sie einen Anruf",
-        "subtitle": "Möchten Sie erst einmal sprechen? Buchen Sie 20 Minuten mit unserem Team.",
-        "cta": "In Calendly buchen",
-        "info": "Bei Fragen erreichen Sie uns unter voicelink@finitsolutions.be. Wir antworten innerhalb von 24 Stunden."
-      }
+        "title": "Erst kennenlernen?",
+        "subtitle": "Möchten Sie zuerst besprechen, ob VoiceLink zu Ihren Kunden oder Ihrem Netzwerk passt? Buchen Sie ein 20-minütiges Gespräch mit unserem Team.",
+        "cta": "Kennenlernen planen",
+        "contactBefore": "Fragen? Senden Sie eine E-Mail an ",
+        "contactAfter": ". Wir antworten in der Regel innerhalb eines Werktags."
+      },
+      "subtitle": "Melden Sie sich an oder planen Sie zuerst ein Kennenlernen."
     }
   },
   "languagePicker": {
@@ -1694,5 +1726,31 @@
     "subtitle": "VoiceLink antwortet ab jetzt immer in dieser Sprache, unabhängig davon, in welcher Sprache du sprichst.",
     "confirm": "Bestätigen",
     "editLater": "Du kannst dies später in deinem Profil ändern."
+  },
+  "customSolutions": {
+    "title": "Möchtest du eine maßgeschneiderte VoiceLink-Lösung?",
+    "subtitle": "Wir bauen maßgeschneiderte Sprachlösungen für jedes CRM oder Geschäftssystem. Wenn es eine API hat, können wir es anbinden.",
+    "twoExamples": "Zwei Beispiele:",
+    "adaptsToAnyIndustry": "VoiceLink passt sich an jede Branche oder jeden Workflow an, der Sprache-zu-Daten-Umwandlung benötigt.",
+    "fieldTechnicians": {
+      "title": "Servicetechniker",
+      "description": "Techniker sprechen Serviceberichte ein, während sie zwischen Einsätzen fahren. Sprachnotizen erstellen automatisch strukturierte Berichte mit Auftragsdetails, verwendeten Teilen und aufgewendeter Zeit.",
+      "features": "Individuelle Berichtsformate • Echtzeit-Sync • Mobile-first"
+    },
+    "propertyManagement": {
+      "title": "Immobilienverwaltung",
+      "description": "Immobilienverwalter erfassen Wartungsanfragen, Mieterinteraktionen und Inspektionsnotizen per Sprache. KI erstellt automatisch Arbeitsaufträge, aktualisiert Mieterdaten und plant Follow-ups.",
+      "features": "Erstellung von Arbeitsaufträgen • Mieterkommunikation • Wartungsplanung"
+    },
+    "connectAnyCrm": "Jedes CRM verbinden",
+    "integrateWithAnySystem": "Wir integrieren jedes System, das eine API hat",
+    "apiSupport": "+ Jedes System mit REST-API, GraphQL oder Webhooks",
+    "readyToBuild": "Bereit, deine maßgeschneiderte Lösung zu bauen?",
+    "customSolutionDescription": "Erzähl uns von deinem Workflow, und wir zeigen dir, wie Sprachtechnologie deine Geschäftsabläufe verändern kann. Jede Lösung wird genau auf deine Bedürfnisse zugeschnitten.",
+    "scheduleCustomDemo": "Individuelle Demo planen",
+    "discussYourNeeds": "Besprich deine Anforderungen",
+    "freeConsultation": "Kostenlose Beratung",
+    "customProofOfConcept": "Individueller Proof of Concept",
+    "tailoredImplementation": "Maßgeschneiderte Umsetzung"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -114,7 +114,7 @@
     "integrations": "What it does",
     "contact": "Contact",
     "maatwerkAI": "Custom AI",
-    "affiliate": "Partner program",
+    "affiliate": "Become a partner",
     "urgentQuestions": "Prefer direct contact?",
     "callUs": "Call us anytime",
     "callHours": "Mon-Sat · 8:30-19:00"
@@ -122,17 +122,23 @@
   "hero": {
     "title": "Just...",
     "mainTitle": "Talk to your CRM",
-    "subtitle1_pre": "Connect your",
+    "subtitle1_pre": "VoiceLink connects",
     "subtitle1_crm": "Teamleader CRM",
     "subtitle1_mid": "with",
     "subtitle1_wa": "WhatsApp",
-    "subtitle1_post": "and handle all your admin with a simple voice message.",
+    "subtitle1_post": ", so a single voice note lets you add client notes, log follow-ups, create tasks and pull up CRM information. Without ever opening Teamleader.",
     "subtitle2": "Turn voice messages into structured data instantly.",
-    "getStartedFree": "Get Started Free",
-    "watchDemo": "Watch Demo",
+    "getStartedFree": "Start for free",
+    "watchDemo": "Watch demo",
+    "howToInstall": "How to set up?",
     "oneClickSetup": "One-click CRM Connection",
     "whatsappSetup": "Connect WhatsApp\nin 2 minutes",
-    "carouselTitle": "Explore what VoiceLink does inside your CRM"
+    "carouselTitle": "What can VoiceLink do in your CRM?",
+    "staticTitle": "Manage your CRM through WhatsApp",
+    "subtitleFull": "VoiceLink connects Teamleader with WhatsApp, so a single voice note lets you add client notes, log follow-ups, create tasks and pull up CRM information. Without ever opening Teamleader.",
+    "bulletSetup": "Set up in minutes",
+    "bulletNoTech": "No technical knowledge needed",
+    "bulletNoCard": "No credit card required"
   },
   "auth": {
     "modal": {
@@ -828,8 +834,8 @@
     }
   },
   "pricing": {
-    "title": "Simple, Transparent Pricing",
-    "subtitle": "Per-seat pricing with clear message limits. Start free, scale as you grow.",
+    "title": "Less admin. More time for clients.",
+    "subtitle": "Start for free and manage your CRM directly through WhatsApp.",
     "monthly": "Monthly",
     "yearly": "Yearly",
     "save20": "Save 20%",
@@ -856,7 +862,7 @@
     "startFreeTrial": "Start Free Trial",
     "freeTrial": "1-Month Free Trial",
     "custom": "Custom",
-    "getCustomQuote": "Get Custom Quote",
+    "getCustomQuote": "Get in touch",
     "allPlansInclude": "All plans include real-time CRM sync, WhatsApp integration, and multi-language support.",
     "free": "Free",
     "users": "users",
@@ -866,35 +872,68 @@
     "autoTopUpInfo": "Auto top-up — €7 per 100 credits",
     "cards": {
       "freetrial": {
-        "name": "Free Trial",
+        "name": "Free",
         "description": "Try before you buy",
-        "cta": "Start Free",
+        "cta": "Try it free now",
         "subtext": "100 free credits — no card needed",
-        "billingNote": "One-time credits, no card needed"
+        "billingNote": "One-time credits, no card needed",
+        "features": [
+          "Email support"
+        ]
       },
       "starter": {
         "name": "Starter",
         "description": "For casual users",
-        "cta": "Start with Starter",
-        "subtext": "Email support included"
+        "cta": "Try it free now",
+        "subtext": "Email support included",
+        "features": [
+          "Everything from the trial, plus:",
+          "1-on-1 support calls"
+        ]
       },
       "professional": {
         "name": "Professional",
         "description": "For daily users",
         "badge": "Most Popular",
-        "cta": "Go to Professional"
+        "cta": "Try it free now",
+        "features": [
+          "Everything from Starter, plus:",
+          "Dedicated account manager",
+          "Add multiple team members"
+        ]
       },
       "business": {
         "name": "Business",
         "description": "For power users",
-        "cta": "Go to Business"
+        "cta": "Try it free now",
+        "features": [
+          "Everything from Professional, plus:",
+          "Custom features on request"
+        ]
       },
       "enterprise": {
         "name": "Enterprise",
         "description": "For organizations (25+ users)",
-        "contactForPricing": "Tailored to your needs"
+        "contactForPricing": "Tailored to your needs",
+        "features": [
+          "Fully tailored to your company structure"
+        ]
       }
-    }
+    },
+    "creditUses": [
+      "± messages per month",
+      "Contacts",
+      "Notes",
+      "Tasks",
+      "Appointments",
+      "Quotes & invoices",
+      "More"
+    ],
+    "perUserLine1": "user /",
+    "perUserLine2": "month",
+    "totalBilledAnnually": "Total of €{{total}} /month, billed annually",
+    "creditUsesTitle": "Use your credits for:",
+    "includedHeading": "Included:"
   },
   "features": {
     "title": "CRM Integrations",
@@ -910,22 +949,22 @@
   },
   "howItWorks": {
     "title": "How does it work?",
-    "subtitle": "From voice message to your CRM in four steps",
+    "subtitle": "From voice to your CRM in four steps",
     "step1": {
       "title": "Send a message",
-      "description": "Open WhatsApp and send a voice note or text — just like you normally would. Add new info to your CRM or look up existing contacts and deals."
+      "description": "Open WhatsApp and send a voice note or text, just like you're used to. Add information to your CRM or pull up existing contacts, deals, tasks and appointments."
     },
     "step2": {
-      "title": "VoiceLink picks out the info",
-      "description": "VoiceLink spots the key info — names, numbers, appointments, notes — and figures out what to do with it."
+      "title": "The right information gets processed",
+      "description": "Contacts, notes, follow-ups, appointments and opportunities are automatically recognized and linked to the right client or deal."
     },
     "step3": {
-      "title": "You get a summary",
-      "description": "Instantly get an overview back in WhatsApp. VoiceLink also thinks ahead: it can ask questions or suggest next steps."
+      "title": "You get instant feedback",
+      "description": "You see which information was found and which actions will be carried out. Something missing? You immediately get a question or suggestion back."
     },
     "step4": {
-      "title": "Everything is in your CRM",
-      "description": "Contacts, notes and tasks show up automatically in your CRM. Done."
+      "title": "Everything ends up where it belongs",
+      "description": "New information is added to your CRM and requested information appears right back in WhatsApp."
     },
     "coreFunctionalities": {
       "title": "Core Functionalities",
@@ -979,13 +1018,13 @@
     "tailoredImplementation": "Tailored implementation"
   },
   "finalCta": {
-    "title": "Talk. Your CRM does the rest.",
-    "subtitle": "Connect WhatsApp, send a voice note, and VoiceLink writes contacts, notes and tasks straight to your CRM.",
-    "startFreeTrial": "Start Free Trial",
-    "watchDemo": "Watch Demo",
+    "title": "Ready to try VoiceLink for free?",
+    "subtitle": "Connect your CRM with WhatsApp and add notes, log follow-ups and pull up client information through a single conversation.",
+    "startFreeTrial": "Start for free",
+    "watchDemo": "Watch demo",
     "freeTrialFeatures": {
-      "freeTrialDays": "1-Month Free Trial",
-      "noSetupFees": "No setup fees",
+      "freeTrialDays": "100 free credits",
+      "noSetupFees": "No credit card required",
       "cancelAnytime": "Cancel anytime"
     }
   },
@@ -1006,8 +1045,8 @@
     "prefersThursday": "Prefers Thursday PM calls"
   },
   "footer": {
-    "ctaHeadline": "Talk. We'll take care of the rest.",
-    "ctaSubline": "One voice note on WhatsApp is all it takes to keep your CRM up to date.",
+    "ctaHeadline": "Just… talk.\nYour CRM stays up to date.",
+    "ctaSubline": "Add information, pull up client details and manage your CRM directly through WhatsApp.",
     "copyright": "© 2025 Finit Solutions",
     "privacy": "Privacy",
     "saasAgreement": "SaaS Agreement",
@@ -1150,11 +1189,11 @@
   },
   "problemAgitation": {
     "title": "Sound familiar?",
-    "subtitle": "Sales teams lose hours every week on manual CRM work.",
-    "pain1": "You forget to log calls in your CRM because you're already on the next one.",
-    "pain2": "Notes from client meetings live in your head — or on a napkin.",
-    "pain3": "Your pipeline looks outdated because updating it takes too long.",
-    "pain4": "Follow-ups slip through the cracks and deals go cold."
+    "subtitle": "Your CRM often lags behind what's actually happening inside your business.",
+    "pain1": "You forget to log conversations because you're already on to the next client.",
+    "pain2": "Important information stays stuck in WhatsApp, notes or your head.",
+    "pain3": "Follow-ups slip through the cracks because admin keeps piling up.",
+    "pain4": "Updating your CRM feels like extra work on top of your real work."
   },
   "integrations": {
     "title": "Works with your CRM",
@@ -1643,48 +1682,39 @@
   },
   "affiliate": {
     "hero": {
-      "title": "Build recurring revenue by introducing VoiceLink to your network",
-      "subtitle": "Become a VoiceLink partner and earn 20% recurring commission on every referred customer. Long attribution window, monthly payouts, everything provided.",
-      "stat1": "recurring commission",
-      "stat2": "attribution window",
-      "stat3": "tail after cancellation",
-      "days": "days",
-      "months": "months",
+      "title": "Become a VoiceLink partner",
+      "subtitle": "Introduce VoiceLink to companies in your network and earn 20% recurring commission for as long as they stay a customer. We handle the demo, onboarding and support.",
       "cta1": "Become a partner",
-      "cta2": "Book a call"
+      "cta2": "Book an intro call"
     },
     "howItWorks": {
       "title": "How it works",
       "step1": {
         "title": "Register a lead",
-        "description": "Send an email to voicelink@finitsolutions.be with name, company, and context."
+        "description": "Send an email to voicelink@finitsolutions.be with the company name, a contact person and some context."
       },
       "step2": {
-        "title": "Customer signs within 90 days",
-        "description": "If your lead subscribes within 90 days, you earn commission."
+        "title": "The customer goes live",
+        "description": "If your lead becomes a customer within 90 days, they're assigned to you."
       },
       "step3": {
-        "title": "Receive 20% recurring",
-        "description": "As long as your customer pays, you receive 20% of their monthly subscription value."
-      },
-      "step4": {
-        "title": "Payout quarterly",
-        "description": "Monthly if you have 5+ active customers, otherwise quarterly after invoice."
+        "title": "Earn recurring commission",
+        "description": "You receive 20% commission for as long as the customer stays active. Payouts are quarterly. From 5 active customers we switch to monthly payouts."
       }
     },
     "whyPartner": {
-      "title": "Why become a partner?",
+      "title": "Why partners recommend VoiceLink",
       "point1": {
-        "title": "Recurring, not one-shot",
-        "description": "Build a portfolio, not one-off commissions. Long-term relationship with your customers."
+        "title": "We do the work",
+        "description": "We take care of demos, onboarding, support and follow-up. You make the introduction, we do the rest."
       },
       "point2": {
-        "title": "Generous attribution window",
-        "description": "90 days to introduce a customer. Recurring commission for as long as they stay active and paying."
+        "title": "Fits almost any company",
+        "description": "Almost every company works with a CRM today and loses time to admin, follow-up or scattered customer information."
       },
       "point3": {
-        "title": "Everything provided",
-        "description": "Pitch deck, demo videos, one-pager, FAQ. You introduce, we handle the rest."
+        "title": "Easy to show the value",
+        "description": "The value is immediately clear: customers manage their CRM through WhatsApp without changing the way they already work."
       }
     },
     "accordion": {
@@ -1735,11 +1765,13 @@
         "error": "Something went wrong. Send us an email at voicelink@finitsolutions.be."
       },
       "calendly": {
-        "title": "Or book a call",
-        "subtitle": "Prefer to chat first? Book 20 minutes with our team.",
-        "cta": "Book in Calendly",
-        "info": "If you have any questions, reach us at voicelink@finitsolutions.be. We respond within 24 hours."
-      }
+        "title": "Want to talk first?",
+        "subtitle": "Want to discuss whether VoiceLink fits your customers or network first? Book a 20-minute call with our team.",
+        "cta": "Book an intro call",
+        "contactBefore": "Questions? Send an email to ",
+        "contactAfter": ". We usually reply within one business day."
+      },
+      "subtitle": "Sign up or schedule an intro call first."
     }
   },
   "languagePicker": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -521,7 +521,7 @@
     "integrations": "Ce que ça fait",
     "contact": "Contact",
     "maatwerkAI": "IA sur mesure",
-    "affiliate": "Programme partenaire",
+    "affiliate": "Devenir partenaire",
     "urgentQuestions": "Préférez-vous un contact direct ?",
     "callUs": "Appelez-nous",
     "callHours": "lun-sam · 8h30-19h"
@@ -529,17 +529,23 @@
   "hero": {
     "title": "Simplement...",
     "mainTitle": "Parlez à votre CRM",
-    "subtitle1_pre": "Connect your",
+    "subtitle1_pre": "VoiceLink connecte",
     "subtitle1_crm": "Teamleader CRM",
-    "subtitle1_mid": "with",
+    "subtitle1_mid": "à",
     "subtitle1_wa": "WhatsApp",
-    "subtitle1_post": "and handle all your admin with a simple voice message.",
+    "subtitle1_post": " : un simple message vocal vous permet d'ajouter des notes clients, d'enregistrer des suivis, de créer des tâches et de consulter les informations de votre CRM. Sans jamais ouvrir Teamleader.",
     "subtitle2": "Transformez les messages vocaux en données structurées instantanément.",
-    "getStartedFree": "Commencer Gratuitement",
-    "watchDemo": "Voir la Démo",
+    "getStartedFree": "Commencer gratuitement",
+    "watchDemo": "Voir la démo",
+    "howToInstall": "Comment l'installer ?",
     "oneClickSetup": "Connexion CRM en un clic",
     "whatsappSetup": "Connectez WhatsApp\nen 2 minutes",
-    "carouselTitle": "See what VoiceLink does inside your CRM"
+    "carouselTitle": "Que peut faire VoiceLink dans votre CRM ?",
+    "staticTitle": "Gérez votre CRM via WhatsApp",
+    "subtitleFull": "VoiceLink connecte Teamleader à WhatsApp : un simple message vocal vous permet d'ajouter des notes clients, d'enregistrer des suivis, de créer des tâches et de consulter les informations de votre CRM. Sans jamais ouvrir Teamleader.",
+    "bulletSetup": "Configuré en quelques minutes",
+    "bulletNoTech": "Aucune connaissance technique requise",
+    "bulletNoCard": "Aucune carte de crédit requise"
   },
   "features": {
     "title": "Intégrations CRM",
@@ -749,8 +755,8 @@
     }
   },
   "pricing": {
-    "title": "Tarification Simple et Transparente",
-    "subtitle": "Prix par utilisateur avec des limites de messages claires. Commencez gratuitement, évoluez à votre rythme.",
+    "title": "Moins d'administratif. Plus de temps pour vos clients.",
+    "subtitle": "Commencez gratuitement et gérez votre CRM directement via WhatsApp.",
     "monthly": "Mensuel",
     "yearly": "Annuel",
     "save20": "Économisez 20%",
@@ -777,7 +783,7 @@
     "startFreeTrial": "Commencer l'Essai Gratuit",
     "freeTrial": "Essai gratuit de 1 mois",
     "custom": "Sur mesure",
-    "getCustomQuote": "Obtenir un Devis",
+    "getCustomQuote": "Nous contacter",
     "allPlansInclude": "Tous les plans incluent la synchronisation CRM en temps réel, l'intégration WhatsApp et le support multilingue.",
     "free": "Gratuit",
     "users": "utilisateurs",
@@ -787,54 +793,87 @@
     "autoTopUpInfo": "Recharge automatique — €7 par 100 crédits",
     "cards": {
       "freetrial": {
-        "name": "Essai Gratuit",
+        "name": "Gratuit",
         "description": "Essayez avant d'acheter",
-        "cta": "Commencer Gratuitement",
+        "cta": "Essayer gratuitement",
         "subtext": "100 crédits gratuits — sans carte",
-        "billingNote": "Crédits uniques, sans carte"
+        "billingNote": "Crédits uniques, sans carte",
+        "features": [
+          "Support par e-mail"
+        ]
       },
       "starter": {
         "name": "Starter",
         "description": "Utilisation occasionnelle",
-        "cta": "Commencer avec Starter",
-        "subtext": "Support par e-mail inclus"
+        "cta": "Essayer gratuitement",
+        "subtext": "Support par e-mail inclus",
+        "features": [
+          "Tout de la période d'essai, plus :",
+          "Appels de support en tête-à-tête"
+        ]
       },
       "professional": {
         "name": "Professionnel",
         "description": "Utilisation quotidienne",
         "badge": "Le Plus Populaire",
-        "cta": "Passer à Professional"
+        "cta": "Essayer gratuitement",
+        "features": [
+          "Tout de Starter, plus :",
+          "Gestionnaire de compte dédié",
+          "Ajouter plusieurs membres d'équipe"
+        ]
       },
       "business": {
         "name": "Business",
         "description": "Utilisation intensive",
-        "cta": "Passer à Business"
+        "cta": "Essayer gratuitement",
+        "features": [
+          "Tout de Professional, plus :",
+          "Fonctionnalités sur mesure sur demande"
+        ]
       },
       "enterprise": {
         "name": "Entreprise",
         "description": "Pour les organisations (25+ utilisateurs)",
-        "contactForPricing": "Adapté à vos besoins"
+        "contactForPricing": "Adapté à vos besoins",
+        "features": [
+          "Entièrement adapté à la structure de votre entreprise"
+        ]
       }
-    }
+    },
+    "creditUses": [
+      "± messages par mois",
+      "Contacts",
+      "Notes",
+      "Tâches",
+      "Rendez-vous",
+      "Devis & factures",
+      "Plus"
+    ],
+    "perUserLine1": "utilisateur /",
+    "perUserLine2": "mois",
+    "totalBilledAnnually": "Total de €{{total}} /mois, facturé annuellement",
+    "creditUsesTitle": "Utilisez vos crédits pour :",
+    "includedHeading": "Inclus :"
   },
   "howItWorks": {
     "title": "Comment ça marche ?",
-    "subtitle": "D'un message vocal à votre CRM en quatre étapes",
+    "subtitle": "De la voix à votre CRM en quatre étapes",
     "step1": {
       "title": "Envoyez un message",
-      "description": "Ouvrez WhatsApp et envoyez un message vocal ou texte — comme d'habitude. Ajoutez de nouvelles infos à votre CRM ou recherchez des contacts et deals existants."
+      "description": "Ouvrez WhatsApp et envoyez un message vocal ou texte, comme d'habitude. Ajoutez des informations à votre CRM ou consultez vos contacts, affaires, tâches et rendez-vous existants."
     },
     "step2": {
-      "title": "VoiceLink repère les infos",
-      "description": "VoiceLink détecte les infos clés — noms, numéros, rendez-vous, notes — et détermine quoi en faire."
+      "title": "Les bonnes informations sont traitées",
+      "description": "Contacts, notes, suivis, rendez-vous et opportunités sont automatiquement reconnus et associés au bon client ou à la bonne affaire."
     },
     "step3": {
-      "title": "Vous recevez un résumé",
-      "description": "Un aperçu vous revient directement dans WhatsApp. VoiceLink anticipe aussi : il peut poser des questions ou proposer des actions."
+      "title": "Vous recevez un retour immédiat",
+      "description": "Vous voyez quelles informations ont été trouvées et quelles actions seront effectuées. Il manque quelque chose ? Vous recevez aussitôt une question ou une suggestion."
     },
     "step4": {
-      "title": "Tout est dans votre CRM",
-      "description": "Contacts, notes et tâches apparaissent automatiquement dans votre CRM. C'est fait."
+      "title": "Tout se retrouve à sa place",
+      "description": "Les nouvelles informations sont ajoutées à votre CRM et les informations demandées réapparaissent directement dans WhatsApp."
     },
     "coreFunctionalities": {
       "title": "Fonctionnalités Principales",
@@ -888,14 +927,14 @@
     "tailoredImplementation": "Implémentation sur mesure"
   },
   "finalCta": {
-    "title": "Parlez. Votre CRM fait le reste.",
-    "subtitle": "Connectez WhatsApp, envoyez un message vocal et VoiceLink inscrit contacts, notes et tâches directement dans votre CRM.",
-    "startFreeTrial": "Commencer l'Essai Gratuit",
-    "watchDemo": "Voir la Démo",
+    "title": "Prêt à essayer VoiceLink gratuitement ?",
+    "subtitle": "Connectez votre CRM à WhatsApp et ajoutez des notes, enregistrez des suivis et consultez les informations clients en une seule conversation.",
+    "startFreeTrial": "Commencer gratuitement",
+    "watchDemo": "Voir la démo",
     "freeTrialFeatures": {
-      "freeTrialDays": "Essai gratuit de 1 mois",
-      "noSetupFees": "Aucuns frais d'installation",
-      "cancelAnytime": "Annuler à tout moment"
+      "freeTrialDays": "100 crédits gratuits",
+      "noSetupFees": "Aucune carte de crédit requise",
+      "cancelAnytime": "Annulable à tout moment"
     }
   },
   "phoneMockup": {
@@ -1044,11 +1083,11 @@
   },
   "problemAgitation": {
     "title": "Ça vous parle ?",
-    "subtitle": "Les équipes commerciales perdent des heures chaque semaine en travail CRM manuel.",
-    "pain1": "Vous oubliez de saisir vos appels dans le CRM parce que vous êtes déjà au suivant.",
-    "pain2": "Les notes de vos réunions clients restent dans votre tête — ou sur une serviette.",
-    "pain3": "Votre pipeline semble dépassé parce que le mettre à jour prend trop de temps.",
-    "pain4": "Les relances passent entre les mailles et les deals refroidissent."
+    "subtitle": "Votre CRM est souvent en retard sur ce qui se passe réellement dans votre entreprise.",
+    "pain1": "Vous oubliez d'enregistrer vos conversations parce que vous êtes déjà avec le client suivant.",
+    "pain2": "Des informations importantes restent coincées dans WhatsApp, dans des notes ou dans votre tête.",
+    "pain3": "Les suivis passent à travers les mailles du filet parce que l'administratif s'accumule.",
+    "pain4": "Mettre à jour votre CRM ressemble à du travail en plus de votre vrai travail."
   },
   "integrations": {
     "title": "Fonctionne avec votre CRM",
@@ -1084,8 +1123,8 @@
     "a7": "Oui. VoiceLink comprend pratiquement toutes les langues. Vous pouvez parler ou écrire dans la langue qui vous convient — néerlandais, anglais, français, allemand, espagnol et bien d'autres. VoiceLink répond toujours dans la même langue que vous."
   },
   "footer": {
-    "ctaHeadline": "Parlez. On s'occupe du reste.",
-    "ctaSubline": "Un seul message vocal sur WhatsApp suffit pour garder votre CRM à jour.",
+    "ctaHeadline": "Just… talk.\nVotre CRM reste à jour.",
+    "ctaSubline": "Ajoutez des informations, consultez les données clients et gérez votre CRM directement via WhatsApp.",
     "copyright": "© 2025 Finit Solutions",
     "privacy": "Confidentialité",
     "saasAgreement": "Accord SaaS",
@@ -1548,48 +1587,39 @@
   },
   "affiliate": {
     "hero": {
-      "title": "Générez un revenu récurrent en présentant VoiceLink à votre réseau",
-      "subtitle": "Devenez partenaire VoiceLink et gagnez 20% de commission récurrente sur chaque client référé. Longue fenêtre d'attribution, versements mensuels, tout est fourni.",
-      "stat1": "commission récurrente",
-      "stat2": "fenêtre d'attribution",
-      "stat3": "revenus après résiliation",
-      "days": "jours",
-      "months": "mois",
+      "title": "Devenez partenaire VoiceLink",
+      "subtitle": "Présentez VoiceLink aux entreprises de votre réseau et recevez 20% de commission récurrente tant qu'elles restent clientes. Nous nous occupons de la démo, de l'onboarding et du support.",
       "cta1": "Devenir partenaire",
-      "cta2": "Réserver un appel"
+      "cta2": "Planifier une rencontre"
     },
     "howItWorks": {
       "title": "Comment ça marche",
       "step1": {
-        "title": "Enregistrez un prospect",
-        "description": "Envoyez un e-mail à voicelink@finitsolutions.be avec le nom, l'entreprise et le contexte."
+        "title": "Enregistrez un lead",
+        "description": "Envoyez un e-mail à voicelink@finitsolutions.be avec le nom de l'entreprise, une personne de contact et un peu de contexte."
       },
       "step2": {
-        "title": "Le client signe dans les 90 jours",
-        "description": "Si votre prospect s'abonne dans les 90 jours, vous gagnez la commission."
+        "title": "Le client devient actif",
+        "description": "Si votre lead devient client dans les 90 jours, il vous est attribué."
       },
       "step3": {
-        "title": "Recevez 20% de revenu récurrent",
-        "description": "Tant que votre client paie, vous recevez 20% de la valeur de son abonnement mensuel."
-      },
-      "step4": {
-        "title": "Versement trimestriel",
-        "description": "Mensuel si vous avez 5+ clients actifs, sinon trimestriel après facture."
+        "title": "Recevez une commission récurrente",
+        "description": "Vous recevez 20% de commission tant que le client reste actif. Les paiements se font par trimestre. À partir de 5 clients actifs, nous passons à des paiements mensuels."
       }
     },
     "whyPartner": {
-      "title": "Pourquoi devenir partenaire?",
+      "title": "Pourquoi les partenaires recommandent VoiceLink",
       "point1": {
-        "title": "Récurrent, pas ponctuel",
-        "description": "Constituez un portefeuille, pas des commissions ponctuelles. Relation à long terme avec vos clients."
+        "title": "Nous faisons le travail",
+        "description": "Démos, onboarding, support et suivi : nous nous en chargeons. Vous faites l'introduction, nous faisons le reste."
       },
       "point2": {
-        "title": "Large fenêtre d'attribution",
-        "description": "90 jours pour présenter un client. Commission récurrente tant que le client reste actif et paie."
+        "title": "Convient à presque toute entreprise",
+        "description": "Presque toutes les entreprises utilisent aujourd'hui un CRM et perdent du temps en administration, en suivi ou à cause d'informations clients éparpillées."
       },
       "point3": {
-        "title": "Tout est fourni",
-        "description": "Deck de présentation, vidéos de démonstration, one-pager, FAQ. Vous présentez, nous gérons le reste."
+        "title": "Facile de montrer la valeur",
+        "description": "La valeur est immédiatement claire : les clients gèrent leur CRM via WhatsApp sans changer leur façon de travailler."
       }
     },
     "accordion": {
@@ -1625,7 +1655,7 @@
       }
     },
     "conversion": {
-      "title": "Prêt à devenir partenaire?",
+      "title": "Prêt à devenir partenaire ?",
       "form": {
         "title": "S'inscrire",
         "name": "Nom complet",
@@ -1640,11 +1670,13 @@
         "error": "Quelque chose s'est mal passé. Envoyez-nous un e-mail à voicelink@finitsolutions.be."
       },
       "calendly": {
-        "title": "Ou réserver un appel",
-        "subtitle": "Préférez discuter d'abord ? Réservez 20 minutes avec notre équipe.",
-        "cta": "Réserver in Calendly",
-        "info": "Si vous avez des questions, contactez-nous à voicelink@finitsolutions.be. Nous répondons dans les 24 heures."
-      }
+        "title": "Envie d'en parler d'abord ?",
+        "subtitle": "Vous voulez d'abord voir si VoiceLink convient à vos clients ou à votre réseau ? Réservez un appel de 20 minutes avec notre équipe.",
+        "cta": "Planifier une rencontre",
+        "contactBefore": "Des questions ? Envoyez un e-mail à ",
+        "contactAfter": ". Nous répondons généralement dans un délai d'un jour ouvrable."
+      },
+      "subtitle": "Inscrivez-vous ou planifiez d'abord une rencontre."
     }
   },
   "languagePicker": {
@@ -1653,5 +1685,28 @@
     "subtitle": "VoiceLink répondra toujours dans cette langue, quelle que soit la langue dans laquelle vous parlez.",
     "confirm": "Confirmer",
     "editLater": "Vous pouvez modifier ceci plus tard dans votre profil."
+  },
+  "dates": {
+    "today": "Aujourd'hui",
+    "yesterday": "Hier",
+    "tomorrow": "Demain",
+    "thisWeek": "Cette semaine",
+    "lastWeek": "La semaine dernière",
+    "nextWeek": "La semaine prochaine",
+    "thisMonth": "Ce mois-ci",
+    "lastMonth": "Le mois dernier",
+    "nextMonth": "Le mois prochain"
+  },
+  "errors": {
+    "authenticationFailed": "Échec de l'authentification",
+    "invalidCredentials": "Identifiants invalides",
+    "networkError": "Une erreur réseau s'est produite",
+    "unexpectedError": "Une erreur inattendue s'est produite",
+    "tryAgain": "Veuillez réessayer"
+  },
+  "numbers": {
+    "currency": "€{{amount}}",
+    "percentage": "{{value}} %",
+    "decimal": "{{value}}"
   }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -85,11 +85,11 @@
     "signOut": "Uitloggen",
     "getStarted": "Gratis Beginnen",
     "backToHome": "Terug naar Home",
-    "howItWorks": "Hoe het werkt",
+    "howItWorks": "Aan de slag",
     "integrations": "Wat het kan",
     "contact": "Contact",
     "maatwerkAI": "Maatwerk AI",
-    "affiliate": "Partnerprogramma",
+    "affiliate": "Word partner",
     "urgentQuestions": "Liever direct contact?",
     "callUs": "Bel gerust op",
     "callHours": "ma-za · 8u30-19u"
@@ -97,17 +97,23 @@
   "hero": {
     "title": "Gewoon...",
     "mainTitle": "Praten met je CRM",
-    "subtitle1_pre": "Connecteer je",
+    "subtitle1_pre": "VoiceLink koppelt",
     "subtitle1_crm": "Teamleader CRM",
     "subtitle1_mid": "met",
     "subtitle1_wa": "WhatsApp",
-    "subtitle1_post": "en doe al je administratie via een simpel spraakbericht.",
+    "subtitle1_post": ", zodat je met één voicenote klantnotities toevoegt, opvolging registreert, taken aanmaakt en CRM-informatie opvraagt. Zonder Teamleader te openen.",
     "subtitle2": "Zet spraakberichten direct om in gestructureerde data.",
-    "getStartedFree": "Gratis Beginnen",
-    "watchDemo": "Bekijk Demo",
+    "getStartedFree": "Start gratis",
+    "watchDemo": "Bekijk demo",
+    "howToInstall": "Hoe installeren?",
     "oneClickSetup": "Eén-klik CRM Verbinding",
     "whatsappSetup": "Verbind WhatsApp\nin 2 minuten",
-    "carouselTitle": "Ontdek wat VoiceLink kan doen in je CRM"
+    "carouselTitle": "Wat kan VoiceLink doen in je CRM?",
+    "staticTitle": "Beheer je CRM via WhatsApp",
+    "subtitleFull": "VoiceLink koppelt Teamleader met WhatsApp, zodat je met één voicenote klantnotities toevoegt, opvolging registreert, taken aanmaakt en CRM-informatie opvraagt. Zonder Teamleader te openen.",
+    "bulletSetup": "Opgezet in enkele minuten",
+    "bulletNoTech": "Geen technische kennis nodig",
+    "bulletNoCard": "Geen creditcard vereist"
   },
   "auth": {
     "page": {
@@ -806,8 +812,8 @@
     }
   },
   "pricing": {
-    "title": "Eenvoudige, Transparante Prijzen",
-    "subtitle": "Prijs per gebruiker met duidelijke berichtlimieten. Start gratis, schaal naarmate je groeit.",
+    "title": "Minder administratie. Meer tijd voor klanten.",
+    "subtitle": "Start gratis en beheer je CRM rechtstreeks via WhatsApp.",
     "monthly": "Maandelijks",
     "yearly": "Jaarlijks",
     "save20": "Bespaar 20%",
@@ -834,7 +840,7 @@
     "startFreeTrial": "Start Gratis Proefperiode",
     "freeTrial": "1 maand gratis proefperiode",
     "custom": "Aangepast",
-    "getCustomQuote": "Vraag Offerte Aan",
+    "getCustomQuote": "Neem contact op",
     "allPlansInclude": "Alle plannen bevatten real-time CRM synchronisatie, WhatsApp integratie en meertalige ondersteuning.",
     "free": "Gratis",
     "users": "gebruikers",
@@ -844,35 +850,68 @@
     "autoTopUpInfo": "Auto top-up beschikbaar — €7 per 100 credits",
     "cards": {
       "freetrial": {
-        "name": "Gratis Proberen",
+        "name": "Gratis",
         "description": "Probeer voor je koopt",
-        "cta": "Start Gratis",
+        "cta": "Probeer nu gratis",
         "subtext": "100 gratis credits — geen kaart nodig",
-        "billingNote": "Eenmalige credits, geen kaart nodig"
+        "billingNote": "Eenmalige credits, geen kaart nodig",
+        "features": [
+          "E-mailsupport"
+        ]
       },
       "starter": {
         "name": "Starter",
         "description": "Voor licht gebruik",
-        "cta": "Start met Starter",
-        "subtext": "E-mail support inbegrepen"
+        "cta": "Probeer nu gratis",
+        "subtext": "E-mail support inbegrepen",
+        "features": [
+          "Alles uit de proefperiode, plus:",
+          "1-op-1 supportgesprekken"
+        ]
       },
       "professional": {
         "name": "Professional",
         "description": "Voor dagelijks gebruik",
         "badge": "Meest Populair",
-        "cta": "Ga naar Professional"
+        "cta": "Probeer nu gratis",
+        "features": [
+          "Alles uit Starter, plus:",
+          "Toegewijde accountmanager",
+          "Meerdere teamleden toevoegen"
+        ]
       },
       "business": {
         "name": "Business",
         "description": "Voor intensief gebruik",
-        "cta": "Ga naar Business"
+        "cta": "Probeer nu gratis",
+        "features": [
+          "Alles uit Professional, plus:",
+          "Maatwerk-features op aanvraag"
+        ]
       },
       "enterprise": {
         "name": "Enterprise",
         "description": "Voor organisaties (25+ gebruikers)",
-        "contactForPricing": "Afgestemd op jouw behoeften"
+        "contactForPricing": "Afgestemd op jouw behoeften",
+        "features": [
+          "Volledig afgestemd op jouw bedrijfsstructuur"
+        ]
       }
-    }
+    },
+    "creditUses": [
+      "± berichten per maand",
+      "Contacten",
+      "Notities",
+      "Taken",
+      "Afspraken",
+      "Offertes & facturen",
+      "Meer"
+    ],
+    "perUserLine1": "gebruiker /",
+    "perUserLine2": "maand",
+    "totalBilledAnnually": "Totaal €{{total}} /maand, jaarlijks gefactureerd",
+    "creditUsesTitle": "Gebruik je credits voor:",
+    "includedHeading": "Inbegrepen:"
   },
   "features": {
     "title": "CRM Integraties",
@@ -888,22 +927,22 @@
   },
   "howItWorks": {
     "title": "Hoe werkt het?",
-    "subtitle": "In vier stappen van spraakbericht naar je CRM",
+    "subtitle": "In vier stappen van spraak naar je CRM",
     "step1": {
       "title": "Stuur een bericht",
-      "description": "Open WhatsApp en stuur een spraakbericht of tekst — zoals je gewend bent. Voeg nieuwe info toe aan je CRM of zoek bestaande contacten en deals op."
+      "description": "Open WhatsApp en stuur een spraakbericht of tekst zoals je gewend bent. Voeg informatie toe aan je CRM of vraag bestaande contacten, deals, taken en afspraken op."
     },
     "step2": {
-      "title": "VoiceLink pikt de info eruit",
-      "description": "VoiceLink herkent de belangrijkste info — namen, nummers, afspraken, notities — en redeneert wat ermee moet gebeuren."
+      "title": "De juiste informatie wordt verwerkt",
+      "description": "Contacten, notities, opvolgingen, afspraken en opportuniteiten worden automatisch herkend en gekoppeld aan de juiste klant of deal."
     },
     "step3": {
-      "title": "Je krijgt een samenvatting",
-      "description": "Meteen een overzicht terug in WhatsApp. VoiceLink denkt ook proactief mee: het kan vragen stellen of zaken voorstellen."
+      "title": "Je krijgt meteen feedback",
+      "description": "Je ziet welke informatie werd gevonden en welke acties zullen worden uitgevoerd. Ontbreekt er iets? Dan krijg je meteen een vraag of suggestie terug."
     },
     "step4": {
-      "title": "Alles staat in je CRM",
-      "description": "Contacten, notities en taken verschijnen automatisch in je CRM. Klaar."
+      "title": "Alles staat waar het hoort",
+      "description": "Nieuwe informatie wordt toegevoegd aan je CRM en opgevraagde informatie verschijnt meteen terug in WhatsApp."
     },
     "coreFunctionalities": {
       "title": "Kernfunctionaliteiten",
@@ -957,8 +996,8 @@
     "tailoredImplementation": "Op maat gemaakte implementatie"
   },
   "footer": {
-    "ctaHeadline": "Just... talk.\nWij zorgen voor de rest.",
-    "ctaSubline": "Eén voicenote op WhatsApp is genoeg om je administratie up-to-date te houden.",
+    "ctaHeadline": "Just… talk.\nJe CRM blijft up-to-date.",
+    "ctaSubline": "Voeg informatie toe, vraag klantgegevens op en beheer je CRM rechtstreeks via WhatsApp.",
     "copyright": "© 2025 Finit Solutions",
     "privacy": "Privacy",
     "saasAgreement": "SaaS Overeenkomst",
@@ -1074,13 +1113,13 @@
     "submitFailed": "Bericht versturen mislukt. Probeer het opnieuw of neem direct contact met ons op."
   },
   "finalCta": {
-    "title": "Je administratie is nog nooit zo snel gegaan",
-    "subtitle": "Verbind je WhatsApp, stuur een spraakbericht en VoiceLink doet de rest.",
-    "startFreeTrial": "Start Gratis Proefperiode",
-    "watchDemo": "Bekijk Demo",
+    "title": "Klaar om VoiceLink gratis uit te proberen?",
+    "subtitle": "Verbind je CRM met WhatsApp en voeg notities toe, registreer opvolgingen en vraag klantinformatie op via één gesprek.",
+    "startFreeTrial": "Start gratis",
+    "watchDemo": "Bekijk demo",
     "freeTrialFeatures": {
-      "freeTrialDays": "1 maand gratis proefperiode",
-      "noSetupFees": "Geen installatiekosten",
+      "freeTrialDays": "100 gratis credits",
+      "noSetupFees": "Geen creditcard vereist",
       "cancelAnytime": "Altijd opzegbaar"
     }
   },
@@ -1142,11 +1181,11 @@
   },
   "problemAgitation": {
     "title": "Klinkt bekend?",
-    "subtitle": "Sales teams verliezen wekelijks uren aan handmatig CRM-werk.",
-    "pain1": "Je vergeet gesprekken te loggen in je CRM omdat je al bij het volgende bent.",
-    "pain2": "Notities van klantgesprekken zitten in je hoofd — of op een servet.",
-    "pain3": "Je pipeline ziet er verouderd uit omdat bijwerken te lang duurt.",
-    "pain4": "Follow-ups glippen door de mazen en deals koelen af."
+    "subtitle": "Je CRM loopt vaak achter op wat er echt gebeurt binnen je bedrijf.",
+    "pain1": "Je vergeet gesprekken te registreren omdat je al met de volgende klant bezig bent.",
+    "pain2": "Belangrijke informatie blijft hangen in WhatsApp, notities of je hoofd.",
+    "pain3": "Opvolgingen glippen door de mazen van het net omdat administratie blijft liggen.",
+    "pain4": "Het bijwerken van je CRM voelt als extra werk bovenop je echte werk."
   },
   "integrations": {
     "title": "Werkt met jouw CRM",
@@ -1635,48 +1674,39 @@
   },
   "affiliate": {
     "hero": {
-      "title": "Bouw recurring revenue door VoiceLink te introduceren bij je netwerk",
-      "subtitle": "Word partner van VoiceLink en ontvang 20% recurring commissie op elke doorverwezen klant. Lang attributievenster, maandelijkse uitbetalingen, alles geleverd.",
-      "stat1": "recurring commissie",
-      "stat2": "attributievenster",
-      "stat3": "tail na opzeg",
-      "days": "dagen",
-      "months": "maanden",
+      "title": "Word partner van VoiceLink",
+      "subtitle": "Introduceer VoiceLink bij bedrijven in je netwerk en ontvang 20% terugkerende commissie zolang ze klant blijven. Wij verzorgen de demo, onboarding en support.",
       "cta1": "Word partner",
-      "cta2": "Boek een call"
+      "cta2": "Plan een kennismaking"
     },
     "howItWorks": {
-      "title": "Hoe het werkt",
+      "title": "Zo werkt het",
       "step1": {
         "title": "Registreer een lead",
-        "description": "Stuur een mail naar voicelink@finitsolutions.be met naam, bedrijf en context."
+        "description": "Stuur een e-mail naar voicelink@finitsolutions.be met de naam van het bedrijf, een contactpersoon en wat context."
       },
       "step2": {
-        "title": "Klant tekent binnen 90 dagen",
-        "description": "Als je lead binnen 90 dagen een abonnement neemt, verdien je commissie."
+        "title": "Klant wordt actief",
+        "description": "Wordt je lead binnen 90 dagen klant, dan wordt die aan jou toegewezen."
       },
       "step3": {
-        "title": "Ontvang 20% recurring",
-        "description": "Zolang je klant betaalt, ontvang je 20% van hun maandelijkse abonnementswaarde."
-      },
-      "step4": {
-        "title": "Uitbetaling per kwartaal",
-        "description": "Maandelijks als je 5+ actieve klanten hebt, anders per kwartaal na factuur."
+        "title": "Ontvang terugkerende commissie",
+        "description": "Je ontvangt 20% commissie zolang de klant actief blijft. Uitbetaling gebeurt per kwartaal. Vanaf 5 actieve klanten schakelen we over naar maandelijkse uitbetaling."
       }
     },
     "whyPartner": {
-      "title": "Waarom partner worden?",
+      "title": "Waarom partners VoiceLink aanbevelen",
       "point1": {
-        "title": "Recurring, niet one-shot",
-        "description": "Bouw een portfolio op, niet incidentele commissies. Langetermijnrelatie met je klanten."
+        "title": "Wij doen het werk",
+        "description": "Demo's, onboarding, support en opvolging nemen wij voor onze rekening. Jij maakt de introductie, wij doen de rest."
       },
       "point2": {
-        "title": "Ruim attributievenster",
-        "description": "90 dagen om een klant te introduceren. Recurring commissie zolang de klant actief is en betaalt."
+        "title": "Past bij vrijwel elk bedrijf",
+        "description": "Vrijwel elk bedrijf werkt vandaag met een CRM en verliest tijd aan administratie, opvolging of verspreide klantinformatie."
       },
       "point3": {
-        "title": "Alles geleverd",
-        "description": "Pitch deck, demo-video's, one-pager, FAQ. Jij introduceert, wij doen de rest."
+        "title": "Makkelijk om de waarde te tonen",
+        "description": "De meerwaarde is meteen duidelijk: klanten kunnen hun CRM beheren via WhatsApp zonder hun bestaande manier van werken te veranderen."
       }
     },
     "accordion": {
@@ -1727,11 +1757,13 @@
         "error": "Er is iets misgegaan. Stuur een mail naar voicelink@finitsolutions.be."
       },
       "calendly": {
-        "title": "Of boek een call",
-        "subtitle": "Liever eerst even sparren? Boek 20 minuten met ons team.",
-        "cta": "Boek in Calendly",
-        "info": "Bij vragen kun je ons altijd bereiken op voicelink@finitsolutions.be. Reageren doen we binnen 24 uur."
-      }
+        "title": "Eerst kennismaken?",
+        "subtitle": "Wil je eerst bespreken of VoiceLink past bij jouw klanten of netwerk? Boek een gesprek van 20 minuten met ons team.",
+        "cta": "Plan een kennismaking",
+        "contactBefore": "Vragen? Stuur een e-mail naar ",
+        "contactAfter": ". We antwoorden meestal binnen één werkdag."
+      },
+      "subtitle": "Meld je aan of plan eerst een kennismaking."
     }
   },
   "languagePicker": {

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@ body {
 }
 
 html {
-  font-size: 15px;
+  font-size: 16px;
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
Frontend updates from the marketeer-feedback redesign branch.

- **getting-started**: trimmed hero top padding so content sits higher (less empty space)
- **howItWorks demo (mobile)**: fixed voice/reply bubble overlap using measured reply height; removed unnecessary CRM auto-scroll + fake scrollbar movement
- **nav**: renamed "Hoe het werkt" → "Aan de slag" (NL)
- in-progress redesign tweaks across homepage, pricing, affiliate, hero, and i18n locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)