### PR TITLE
feat(whatsapp): language-aware welcome v2 with usage tips

### DIFF
--- a/src/components/TestSignup.tsx
+++ b/src/components/TestSignup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { supabase } from '../lib/supabase';
 import { whatsappService } from '../services/whatsappService';
+import i18n from '../i18n';
 import { AuthService } from '../services/authService';
 import { markTestFlow } from '../utils/testFlow';
 import { MessageCircle, Loader2, Check, AlertCircle, ArrowLeft } from 'lucide-react';
@@ -61,7 +62,7 @@ export const TestSignup: React.FC = () => {
     setError(null);
     try {
       await whatsappService.verifyOtp('test', testUserId, otp.trim());
-      whatsappService.sendWelcome('test', testUserId, confirmedPhone).catch(() => {});
+      whatsappService.sendWelcome('test', testUserId, confirmedPhone, i18n.language).catch(() => {});
 
       // Mark this browser as a test-user signup *immediately before* kicking
       // off the OAuth redirect. The flag (TTL 10 min, see utils/testFlow.ts)

--- a/src/components/WhatsAppVerification.tsx
+++ b/src/components/WhatsAppVerification.tsx
@@ -3,6 +3,7 @@ import { MessageCircle, Check, Loader2, AlertCircle, X, Clock } from 'lucide-rea
 import { useAuth } from '../hooks/useAuth';
 import { supabase } from '../lib/supabase';
 import { useI18n } from '../hooks/useI18n';
+import i18n from '../i18n';
 
 interface WhatsAppStatus {
   whatsapp_number: string | null;
@@ -278,7 +279,8 @@ export const WhatsAppVerification: React.FC<WhatsAppVerificationProps> = memo(({
         body: JSON.stringify({
           crm_provider: platform,
           crm_user_id: crmUserId,
-          phone_number: whatsappInput.trim()
+          phone_number: whatsappInput.trim(),
+          language: i18n.language
         })
       });
     } catch (error) {

--- a/src/hooks/useWhatsAppConnect.ts
+++ b/src/hooks/useWhatsAppConnect.ts
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { whatsappService } from '../services/whatsappService';
+import i18n from '../i18n';
 import type { AuthUser } from './useAuth';
 
 export type WhatsAppStatus = 'not_set' | 'pending' | 'active';
@@ -106,7 +107,7 @@ export function useWhatsAppConnect(user: AuthUser | null): WhatsAppConnect {
     try {
       await whatsappService.verifyOtp(user.platform, user.id, otp.trim());
       // Non-blocking welcome message — failures never surface to user
-      whatsappService.sendWelcome(user.platform, user.id, phone.trim()).catch(() => {});
+      whatsappService.sendWelcome(user.platform, user.id, phone.trim(), i18n.language).catch(() => {});
       setSuccess(true);
       setStatus('active');
       setNumber(phone.trim());

--- a/src/services/whatsappService.ts
+++ b/src/services/whatsappService.ts
@@ -5,7 +5,7 @@
 export interface IWhatsAppService {
   sendOtp(platform: string, userId: string, phone: string): Promise<{ expiresAt: string }>;
   verifyOtp(platform: string, userId: string, code: string): Promise<void>;
-  sendWelcome(platform: string, userId: string, phone: string): Promise<void>;
+  sendWelcome(platform: string, userId: string, phone: string, language?: string): Promise<void>;
   cancelPending(platform: string, userId: string): Promise<void>;
 }
 
@@ -48,13 +48,14 @@ class WhatsAppService implements IWhatsAppService {
     if (!data.success) throw new Error(data.error ?? 'Failed to cancel verification.');
   }
 
-  async sendWelcome(platform: string, userId: string, phone: string): Promise<void> {
+  async sendWelcome(platform: string, userId: string, phone: string, language?: string): Promise<void> {
     // Best-effort — swallow errors so the signup flow is never blocked.
     try {
       await this.call('whatsapp-welcome', {
         crm_provider: platform,
         crm_user_id:  userId,
         phone_number: phone,
+        ...(language ? { language } : {}),
       });
     } catch {
       // intentionally silent

--- a/supabase/functions/_shared/whatsapp/providers/factory.ts
+++ b/supabase/functions/_shared/whatsapp/providers/factory.ts
@@ -78,6 +78,15 @@ function createTwilioProvider(): TwilioWhatsAppProvider {
     authToken,
     fromNumber,
     otpTemplateSid:        Deno.env.get('TWILIO_WHATSAPP_OTP_TEMPLATE_SID'),
+    // Welcome v2 templates (approved 2026-06): defaults are the live Content
+    // SIDs; the env vars allow repointing without a redeploy. The legacy
+    // single-SID secret below only applies if a language's SID is unset.
+    welcomeTemplateSids: {
+      nl: Deno.env.get('TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID_NL') ?? 'HXc301334c031e1da6404ef6e1bba5e26a',
+      en: Deno.env.get('TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID_EN') ?? 'HXfb039d77af2f1fac4bb351172759f8ae',
+      fr: Deno.env.get('TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID_FR') ?? 'HXb06256e81a31e89aa74f3ed1916f47aa',
+      de: Deno.env.get('TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID_DE') ?? 'HXaf864af11346cb5eeb82d336436ceab0',
+    },
     welcomeTemplateSid:    Deno.env.get('TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID'),
     teamInviteTemplateSid: Deno.env.get('TWILIO_WHATSAPP_TEAM_INVITE_TEMPLATE_SID'),
     otpFallbackBody:        'Your VoiceLink verification code is: {code}. Valid for 10 minutes.',

--- a/supabase/functions/_shared/whatsapp/providers/interface.ts
+++ b/supabase/functions/_shared/whatsapp/providers/interface.ts
@@ -7,9 +7,11 @@ export interface IWhatsAppOtpSender {
   sendOtp(toPhone: string, code: string): Promise<void>;
 }
 
-/** Sends a one-time welcome message to a newly verified WhatsApp number. */
+/** Sends a one-time welcome message to a newly verified WhatsApp number.
+ *  `language` is a site-locale hint (nl/en/fr/de); implementations fall back
+ *  to their configured default when omitted or unsupported. */
 export interface IWhatsAppWelcomeSender {
-  sendWelcome(toPhone: string): Promise<void>;
+  sendWelcome(toPhone: string, language?: string): Promise<void>;
 }
 
 /** Sends a team invite message with admin name and invite link. */

--- a/supabase/functions/_shared/whatsapp/providers/meta.ts
+++ b/supabase/functions/_shared/whatsapp/providers/meta.ts
@@ -51,14 +51,18 @@ export class MetaWhatsAppProvider implements IWhatsAppProvider {
     log.info('sendOtp completed', { to: normalisePhone(toPhone) });
   }
 
-  async sendWelcome(toPhone: string): Promise<void> {
-    log.info('sendWelcome', { to: normalisePhone(toPhone), template: this.cfg.welcomeTemplateName });
+  async sendWelcome(toPhone: string, language?: string): Promise<void> {
+    // Site locale → Meta template language code; unsupported locales fall
+    // back to the configured default so behaviour matches the Twilio provider.
+    const metaLangs: Record<string, string> = { nl: 'nl', en: 'en_US', fr: 'fr', de: 'de' };
+    const templateLang = (language ? metaLangs[language] : undefined) ?? this.cfg.welcomeTemplateLang;
+    log.info('sendWelcome', { to: normalisePhone(toPhone), template: this.cfg.welcomeTemplateName, lang: templateLang });
     const result = await this.post({
       to: normalisePhone(toPhone),
       type: 'template',
       template: {
         name: this.cfg.welcomeTemplateName,
-        language: { code: this.cfg.welcomeTemplateLang },
+        language: { code: templateLang },
         components: [],
       },
     });

--- a/supabase/functions/_shared/whatsapp/providers/twilio.ts
+++ b/supabase/functions/_shared/whatsapp/providers/twilio.ts
@@ -13,8 +13,12 @@ export interface TwilioProviderConfig {
    *  the code is passed as ContentVariables {"1": code}.
    *  Falls back to a plain Body if not set. */
   otpTemplateSid?: string;
-  /** Twilio Content Template SID for the welcome message. Optional. */
+  /** Twilio Content Template SID for the welcome message. Optional.
+   *  Legacy single-language fallback — superseded by welcomeTemplateSids. */
   welcomeTemplateSid?: string;
+  /** Per-language welcome Content Template SIDs, keyed by site locale
+   *  (nl/en/fr/de). Lookup order: requested language → nl → legacy SID. */
+  welcomeTemplateSids?: Record<string, string>;
   /** Twilio Content Template SID for team invite message. Optional. */
   teamInviteTemplateSid?: string;
   /** Plain-text fallback used when no otpTemplateSid is configured. */
@@ -72,16 +76,20 @@ export class TwilioWhatsAppProvider implements IWhatsAppProvider {
     });
   }
 
-  async sendWelcome(toPhone: string): Promise<void> {
-    log.info('sendWelcome', { to: normalisePhone(toPhone), has_template: !!this.cfg.welcomeTemplateSid });
+  async sendWelcome(toPhone: string, language?: string): Promise<void> {
+    const templateSid =
+      (language ? this.cfg.welcomeTemplateSids?.[language] : undefined)
+      ?? this.cfg.welcomeTemplateSids?.nl
+      ?? this.cfg.welcomeTemplateSid;
+    log.info('sendWelcome', { to: normalisePhone(toPhone), language, has_template: !!templateSid });
     const params = this.baseParams(normalisePhone(toPhone));
 
     let usedTemplate: string | null = null;
     let usedBody: string | null = null;
-    if (this.cfg.welcomeTemplateSid) {
-      params.set('ContentSid', this.cfg.welcomeTemplateSid);
+    if (templateSid) {
+      params.set('ContentSid', templateSid);
       params.set('ContentVariables', JSON.stringify({}));
-      usedTemplate = this.cfg.welcomeTemplateSid;
+      usedTemplate = templateSid;
     } else {
       params.set('Body', this.cfg.welcomeFallbackBody);
       usedBody = this.cfg.welcomeFallbackBody;

--- a/supabase/functions/whatsapp-welcome/index.ts
+++ b/supabase/functions/whatsapp-welcome/index.ts
@@ -23,7 +23,7 @@ Deno.serve(async (req) => {
 
   try {
     const body = await req.json();
-    const { phone_number } = body;
+    const { phone_number, language } = body;
 
     if (!phone_number) {
       r.warn('missing phone_number', { received_keys: Object.keys(body ?? {}) });
@@ -31,17 +31,23 @@ Deno.serve(async (req) => {
       return respond({ success: false, error: 'Missing phone_number' }, 400);
     }
 
+    // Site locale (possibly regionalised, e.g. "nl-BE") → supported welcome
+    // language. Default nl: pre-language callers keep today's behaviour.
+    const SUPPORTED_LANGS = ['nl', 'en', 'fr', 'de'];
+    const normalised = String(language ?? '').slice(0, 2).toLowerCase();
+    const welcomeLang = SUPPORTED_LANGS.includes(normalised) ? normalised : 'nl';
+
     r.info('sending welcome message', {
       phone: phone_number,
+      language: welcomeLang,
+      language_raw: language ?? null,
       provider: Deno.env.get('WHATSAPP_PROVIDER') ?? 'meta',
-      template: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_NAME') ?? 'voicelink_welcome',
-      lang: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_LANG') ?? 'en_US',
     });
 
     const provider = createWhatsAppProvider();
 
     try {
-      await provider.sendWelcome(phone_number);
+      await provider.sendWelcome(phone_number, welcomeLang);
       const meta = (provider as unknown as { lastResult?: Record<string, unknown> }).lastResult;
       const providerClass = (provider as object).constructor?.name ?? 'unknown';
       r.info('welcome message sent successfully', { phone: phone_number, meta, providerClass });
@@ -52,8 +58,7 @@ Deno.serve(async (req) => {
         debug: {
           providerClass,
           provider: Deno.env.get('WHATSAPP_PROVIDER') ?? 'meta',
-          template: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_NAME') ?? 'voicelink_welcome',
-          lang: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_LANG') ?? 'en_US',
+          language: welcomeLang,
         },
       });
     } catch (sendErr) {
@@ -70,8 +75,7 @@ Deno.serve(async (req) => {
         debug: {
           phase: 'provider_send',
           provider: Deno.env.get('WHATSAPP_PROVIDER') ?? 'meta',
-          template: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_NAME') ?? 'voicelink_welcome',
-          lang: Deno.env.get('META_WHATSAPP_WELCOME_TEMPLATE_LANG') ?? 'en_US',
+          language: welcomeLang,
           ...detail,
         },
       });


### PR DESCRIPTION
## What

Replaces the new-user WhatsApp welcome (Twilio template `copy_welcomemessage`, NL-only, Oct 2025) with four per-language **welcome v2** templates that teach the power features:

- 📋 the plan preview is **editable** before anything is saved
- 🗣️ **spell difficult names** or use first + last name
- 👥 assign tasks to a **colleague by full name**
- 🔎 you can **ask questions** (meetings this week, open deals)
- 💬 `/feedback` goes straight to the team

Generic "your CRM" wording — no Teamleader hardcoding, works for every adapter.

## How

- New approved Twilio Content templates `voicelink_welcome_v2_{nl,en,fr,de}` (created 2026-06-11).
- `whatsapp-welcome` edge function accepts optional `language` (normalized, whitelist nl/en/fr/de, **default nl** = previous behavior), passes it to `sendWelcome(toPhone, language?)`.
- Twilio provider picks the per-language SID: env `TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID_{NL,EN,FR,DE}` → baked-in v2 SIDs → legacy `TWILIO_WHATSAPP_WELCOME_TEMPLATE_SID` (now a last-resort fallback; secret can be cleaned up later).
- Meta provider maps the same locale hint onto the template language code (parity, unused in prod).
- Dashboard callers (`useWhatsAppConnect`, `TestSignup`, `WhatsAppVerification`) pass the active i18n language.

## Deploy notes

The edge function is deployed separately (Supabase) once all 4 templates are WhatsApp-approved — FE merge and function deploy are independent; missing `language` falls back to NL v2.

## Test plan

- [x] `npm run build` green; lint findings in touched files are pre-existing on main
- [ ] Prod probe `language:"en"` → debug shows EN v2 SID (after function deploy)
- [ ] Prod probe without `language` → NL v2 (default path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)